### PR TITLE
Use IDs for playback controls

### DIFF
--- a/js/arena.js
+++ b/js/arena.js
@@ -253,15 +253,16 @@ class Simulator {
         this.dragTooltip = document.getElementById('drag-tooltip');
         this.orderTooltip = document.getElementById('order-tooltip');
         // this.btnVectorTime = document.getElementById('btn-vector-time');
-        this.btnPlayPause = document.querySelector('.controlplay');
+        // Playback controls
+        this.btnPlayPause = document.getElementById('play-pause');
         // this.iconPlay = document.getElementById('icon-play');
         // this.iconPause = document.getElementById('icon-pause');
         this.btnRange = document.getElementById('radar-range');
         this.btnAddTrack  = document.getElementById('add-track');
         this.btnDropTrack = document.getElementById('remove-track');
         this.btnScen = document.getElementById('regenerate');
-        this.btnFf = document.querySelector('.control-forward');
-        this.btnRev = document.querySelector('.control-backward');
+        this.btnFf = document.getElementById('future');
+        this.btnRev = document.getElementById('past');
         this.ffSpeedIndicator = document.getElementById('ff-speed-indicator');
         this.revSpeedIndicator = document.getElementById('rev-speed-indicator');
         // this.btnHelp = document.getElementById('btn-help');


### PR DESCRIPTION
## Summary
- select play/pause, rewind and fast-forward controls by ID
- keep event listeners hooked up

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874f32893f483328e69b0741b772f4d