### PR TITLE
Update build script to output dist directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "name": "maneuver",
   "scripts": {
     "start": "parcel ./*.html ",
-    "build": "parcel build ./*.html  --dist-dir ./build"
+    "build": "parcel build ./*.html --dist-dir ./dist"
   },
   "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary
- change Parcel build output to `dist`
- confirm build fails due to missing Parcel

## Testing
- `npm run build` *(fails: `parcel` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68759819222c8325a0e315dada1d7122