### PR TITLE
Disable page scrolling, keep data pane scrollable

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,6 +1,8 @@
 body {
   margin: 0;
   line-height: normal;
+  height: 100vh;
+  overflow: hidden;
 }
 
 :root {


### PR DESCRIPTION
## Summary
- lock body scrolling with `height: 100vh` and `overflow: hidden`

## Testing
- `npm run build` *(fails: parcel not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68763fdc09ec8325af809ad11ef32e80