### PR TITLE
Update Vercel manifest headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,16 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "",
-  "outputDirectory": "."
+  "outputDirectory": ".",
+  "headers": [
+    {
+      "source": "/manifest.webmanifest",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/manifest+json"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add headers entry for `manifest.webmanifest`

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run build` *(fails: `parcel` not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6876444052d4832585ec1639ce0af294