### PR TITLE
Add global user-select styling

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -3,6 +3,12 @@ body {
   line-height: normal;
   height: 100vh;
   overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-drag: none;
+  -webkit-touch-callout: none;
 }
 
 :root {


### PR DESCRIPTION
## Summary
- prevent text selection across the app by applying user-select rules in `global.css`

## Testing
- `grep -R "user-select" css`

------
https://chatgpt.com/codex/tasks/task_e_68767c8a5fe08325adf89fb2447311cf