### PR TITLE
Prevent default pointer highlighting

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -13,6 +13,15 @@ body {
   min-width: 0;
   overflow: visible;
   z-index: 0;
+  /* Prevent text selection and default gestures */
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-user-drag: none;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: none;
 }
 .iconsettings {
   width: 20px;

--- a/js/arena.js
+++ b/js/arena.js
@@ -1651,6 +1651,8 @@ class Simulator {
     }
 
     handleContainerPointerDown(e) {
+        e.preventDefault();
+        e.stopPropagation();
         if (e.pointerType === 'mouse' && e.button !== 0) return;
         this.containerPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
 
@@ -1681,6 +1683,8 @@ class Simulator {
     }
 
     handleContainerPointerMove(e) {
+        e.preventDefault();
+        e.stopPropagation();
         if (!this.containerPointers.has(e.pointerId)) return;
         this.containerPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
 
@@ -1702,6 +1706,8 @@ class Simulator {
     }
 
     handleContainerPointerUp(e) {
+        e.preventDefault();
+        e.stopPropagation();
         this.containerPointers.delete(e.pointerId);
         clearTimeout(this.dragTimer);
         if (this.containerPointers.size < 2) {


### PR DESCRIPTION
## Summary
- disable text selection and gestures on `.radar`
- prevent default pointer behavior when dragging or zooming

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68767fba1dec832582a612319a74d30c