### PR TITLE
Fix radar pan/zoom interactions

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -7,6 +7,20 @@ body {
   width: calc(900px * var(--ui-scale));
   height: calc(900px * var(--ui-scale));
 }
+
+#radarCanvas {
+  display: block;
+  width: calc(900px * var(--ui-scale));
+  height: calc(900px * var(--ui-scale));
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-user-drag: none;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: none;
+}
 .radar {
   align-self: stretch;
   flex: 1;

--- a/js/arena.js
+++ b/js/arena.js
@@ -1653,6 +1653,9 @@ class Simulator {
     handleContainerPointerDown(e) {
         e.preventDefault();
         e.stopPropagation();
+        if (this.mainContainer.setPointerCapture) {
+            this.mainContainer.setPointerCapture(e.pointerId);
+        }
         if (e.pointerType === 'mouse' && e.button !== 0) return;
         this.containerPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
 
@@ -1708,6 +1711,13 @@ class Simulator {
     handleContainerPointerUp(e) {
         e.preventDefault();
         e.stopPropagation();
+        if (this.mainContainer.releasePointerCapture) {
+            try {
+                this.mainContainer.releasePointerCapture(e.pointerId);
+            } catch (err) {
+                // ignore if not captured
+            }
+        }
         this.containerPointers.delete(e.pointerId);
         clearTimeout(this.dragTimer);
         if (this.containerPointers.size < 2) {


### PR DESCRIPTION
## Summary
- add CSS for `#radarCanvas` so long press doesn't highlight and browser gestures are disabled
- capture and release pointer events on the radar container

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_687681b9da708325ace7c667e2d6c24b