### PR TITLE
Increase drag initiation delay

### DIFF
--- a/js/arena.js
+++ b/js/arena.js
@@ -1687,7 +1687,7 @@ class Simulator {
                     this.containerDragStart = { x: e.clientX, y: e.clientY };
                     this.containerDragActive = true;
                 }
-            }, 400);
+            }, 800);
         }
     }
 


### PR DESCRIPTION
## Summary
- tweak handleContainerPointerDown drag delay to 800ms

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876871d688483259c432e71d2fa94a4