### PR TITLE
Fix mobile radar interactions

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -390,6 +390,14 @@ button.buttonbase {
   justify-content: flex-end;
   padding: var(--space-3);
   box-sizing: border-box;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-user-drag: none;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: none;
   gap: var(--space-2);
   line-height: normal;
   letter-spacing: normal;

--- a/css/global.css
+++ b/css/global.css
@@ -10,6 +10,7 @@ body {
   -webkit-user-drag: none;
   -webkit-touch-callout: none;
   -webkit-tap-highlight-color: transparent;
+  touch-action: none;
 }
 
 :root {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="theme-color" content="#000000">

--- a/js/arena.js
+++ b/js/arena.js
@@ -448,15 +448,16 @@ class Simulator {
     _attachEventListeners() {
         // Canvas interaction
         if (window.PointerEvent) {
-            this.canvas?.addEventListener('pointerdown', this.handlePointerDown);
-            this.canvas?.addEventListener('pointerup', this.handlePointerUp);
-            this.canvas?.addEventListener('pointerleave', this.handlePointerUp);
-            this.canvas?.addEventListener('pointercancel', this.handlePointerUp);
-            this.canvas?.addEventListener('pointermove', this.handlePointerMove);
-            this.mainContainer?.addEventListener('pointerdown', this.handleContainerPointerDown);
-            this.mainContainer?.addEventListener('pointermove', this.handleContainerPointerMove);
-            this.mainContainer?.addEventListener('pointerup', this.handleContainerPointerUp);
-            this.mainContainer?.addEventListener('pointercancel', this.handleContainerPointerUp);
+            const opts = { passive: false };
+            this.canvas?.addEventListener('pointerdown', this.handlePointerDown, opts);
+            this.canvas?.addEventListener('pointerup', this.handlePointerUp, opts);
+            this.canvas?.addEventListener('pointerleave', this.handlePointerUp, opts);
+            this.canvas?.addEventListener('pointercancel', this.handlePointerUp, opts);
+            this.canvas?.addEventListener('pointermove', this.handlePointerMove, opts);
+            this.mainContainer?.addEventListener('pointerdown', this.handleContainerPointerDown, opts);
+            this.mainContainer?.addEventListener('pointermove', this.handleContainerPointerMove, opts);
+            this.mainContainer?.addEventListener('pointerup', this.handleContainerPointerUp, opts);
+            this.mainContainer?.addEventListener('pointercancel', this.handleContainerPointerUp, opts);
         } else if ('ontouchstart' in window) {
             const wrap = (handler) => (e) => {
                 const touch = e.touches[0] || e.changedTouches[0];


### PR DESCRIPTION
## Summary
- prevent the page from zooming on mobile
- stop the radar container highlighting when dragging
- allow JavaScript to cancel default pointer actions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687688de1f748325965f564241f4a327