### PR TITLE
Fix ownShip reset on scenario restart

### DIFF
--- a/js/arena.js
+++ b/js/arena.js
@@ -646,7 +646,6 @@ class Simulator {
         clearTimeout(this._myTimeout);
         window.removeEventListener('resize', this._onResize);
         if (this.tracks) this.tracks.length = 0;
-        this.ownShip = null;
         this.tracks = null;
         this.targets = null;
         // wipe canvas to release GPU memory


### PR DESCRIPTION
## Summary
- keep own-ship data when destroying the simulation so it can be reused

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6879b522f2088325aed6f73911a2a298