### PR TITLE
Fix radar redraw by restoring canvas context

### DIFF
--- a/js/arena.js
+++ b/js/arena.js
@@ -379,6 +379,10 @@ class Simulator {
     _initialize() {
         this._attachEventListeners();
 
+        if (!this.ctx) {
+            this.ctx = this.canvas.getContext('2d');
+        }
+
         const BASE_CANVAS_SIZE = 900;
         this.canvas.width = BASE_CANVAS_SIZE * this.DPR;
         this.canvas.height = BASE_CANVAS_SIZE * this.DPR;


### PR DESCRIPTION
## Summary
- reinitialize the radar drawing context when `_initialize()` runs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879c1e83d148325b314d7190b5767c7