### PR TITLE
Adjust radar centering on mobile

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -635,11 +635,13 @@ button.controlplay .placeholder {
   }
 
   body #radarCanvas {
-    left: unset;
-    position: absolute;
-    top: 50%;
+    position: relative;
+    width: calc(100% + 10px);
+    max-width: none;
+    margin-left: auto;
+    margin-right: auto;
     left: 50%;
-    transform: translate(-50%, -50%);
+    transform: translateX(-50%);
   }
 
   .telemetry {
@@ -672,11 +674,11 @@ button.controlplay .placeholder {
   }
   .radar {
     min-width: 100%;
-    position: absolute;
-    height: 100vh;
-    width: 100vw;
-    top:0;
-    left: 0;
+    flex: 1 1 auto;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
   .card {
     flex:1;


### PR DESCRIPTION
## Summary
- adjust `#radarCanvas` to be width `calc(100% + 10px)` and center horizontally
- make the mobile radar container use flex centering rather than absolute positioning

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c30e57a8832589495f35d7432361