### PR TITLE
Add PWA install support and offline caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-title" content="Maneuver">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="theme-color" content="#000000">
     <title>Maneuver : Simulator : Beta</title>
     <link rel="icon" type="image/svg+xml" href="favicons.svg">
     <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="apple-touch-icon" sizes="192x192" href="./icon-192.png">
+    <link rel="apple-touch-icon" href="/icon-192.png" sizes="192x192">
     <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png">
 
     <link rel="stylesheet" href="./css/global.css" />
@@ -264,17 +265,11 @@
       </div>
     </div>
     <script src="./js/arena.js"></script>
+    <script src="/main.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         window.sim = new Simulator(document.getElementById('radarCanvas'));
       });
-    </script>
-    <script>
-      // if ('serviceWorker' in navigator) {
-      //   window.addEventListener('load', () => {
-      //     navigator.serviceWorker.register('./sw.js');
-      //   });
-      // }
     </script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,16 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js')
+      .then(reg => console.log('SW registered:', reg))
+      .catch(err => console.error('SW registration failed:', err));
+  });
+}
+
+function checkStandalone() {
+  const isStandalone = window.matchMedia('(display-mode: standalone)').matches ||
+                       navigator.standalone;
+  if (isStandalone) {
+    console.log('Running in standalone mode');
+  }
+}
+window.addEventListener('load', checkStandalone);

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Offline</title>
+  <link rel="stylesheet" href="/css/global.css" />
+</head>
+<body>
+  <div class="offline-message">You’re offline. Please check your connection.</div>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,40 @@
+const CACHE_NAME = 'maneuver-shell-v1';
+const OFFLINE_URL = '/offline.html';
+const PRECACHE_RESOURCES = [
+  '/',
+  '/index.html',
+  '/main.js',
+  '/styles.css',
+  '/icon-192.png',
+  '/icon-512.png',
+  '/js/arena.js',
+  '/css/global.css',
+  '/css/beta.css',
+  OFFLINE_URL
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_RESOURCES))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).catch(() => caches.match(OFFLINE_URL));
+    })
+  );
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,2 @@
+@import url('/css/global.css');
+@import url('/css/beta.css');


### PR DESCRIPTION
## Summary
- update `<head>` metadata for iOS/Chrome/Firefox install prompts
- add service worker with cache‑first strategy and offline page
- register service worker and detect standalone mode
- add offline page and combined stylesheet

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c40d73848325b30e3953988f221e