### PR TITLE
Add service worker registration script

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/js/service-worker.js');
+  });
+}

--- a/js/service-worker.js
+++ b/js/service-worker.js
@@ -1,0 +1,33 @@
+const CACHE_NAME = 'maneuver-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/js/arena.js',
+  '/js/dynamics.js',
+  '/css/global.css',
+  '/css/beta.css',
+  '/favicons.svg'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+    ))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add `js/main.js` to register service worker at `/js/service-worker.js`
- move service worker implementation to `js/service-worker.js`

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6ba5144c8325afaf9fb09e6eeeb1