### PR TITLE
Add cache-busting version query strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180.png">
     <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png"/>
 
-    <link rel="stylesheet" href="./css/global.css" />
-    <link rel="stylesheet" href="./css/beta.css" />
+    <link rel="stylesheet" href="./css/global.css?v=1.0" />
+    <link rel="stylesheet" href="./css/beta.css?v=1.0" />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=IBM Plex Mono:wght@400;500&display=swap"
@@ -266,6 +266,6 @@
       </div>
     </div>
     <div id="loading" style="display:none">Loading…</div>
-    <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/main.js?v=1.0"></script>
   </body>
 </html>

--- a/offline.html
+++ b/offline.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Offline</title>
-  <link rel="stylesheet" href="/css/global.css" />
+  <link rel="stylesheet" href="/css/global.css?v=1.0" />
 </head>
 <body>
   <div class="offline-message">You’re offline. Please check your connection.</div>

--- a/sw.js
+++ b/sw.js
@@ -1,17 +1,17 @@
 
 // Update CACHE_VERSION on each release to force old caches to clear
-const CACHE_VERSION = 'v1';
+const CACHE_VERSION = 'v2';
 const CACHE_NAME = `maneuver-cache-${CACHE_VERSION}`;
 const ASSETS = [
   '/',
   '/index.html',
   '/manifest.webmanifest',
-  '/js/main.js',
-  '/js/radar-engine.js',
-  '/js/object-pool.js',
-  '/js/cpa-worker.js',
-  '/css/global.css',
-  '/css/beta.css',
+  '/js/main.js?v=1.0',
+  '/js/radar-engine.js?v=1.0',
+  '/js/object-pool.js?v=1.0',
+  '/js/cpa-worker.js?v=1.0',
+  '/css/global.css?v=1.0',
+  '/css/beta.css?v=1.0',
   '/offline.html',
   '/favicons.svg'
 ];


### PR DESCRIPTION
## Summary
- bust Safari caching by adding ?v=1.0 to CSS/JS references
- include versioned URLs in service worker and bump cache version

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d7e52bdd883259b2ac130fd126209