### PR TITLE
Scale mobile radar view

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -591,7 +591,7 @@ button.controlplay .placeholder {
   width: 304px;
 }
 
-@media screen and (max-width: 792px) {
+@media screen and (max-width: 792px) and (orientation: portrait) {
   .beta{
     flex-direction: column;
     align-items: flex-end;
@@ -644,7 +644,7 @@ button.controlplay .placeholder {
 
   body #radarCanvas {
     position: relative;
-    width: calc(100% + 10px);
+    width: calc(100% + 40px);
     max-width: none;
     margin-left: auto;
     margin-right: auto;

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -1523,7 +1523,10 @@ class Simulator {
         const BASE = 900;
         const containerHeight = this.mainContainer.clientHeight;
         const wrapperWidth = this.radarWrapper.clientWidth;
-        const dim = Math.min(wrapperWidth, containerHeight);
+        const isPortraitMobile = window.matchMedia('(max-width: 792px) and (orientation: portrait)').matches;
+        const dim = isPortraitMobile ?
+            Math.min(containerHeight, wrapperWidth + 40) :
+            Math.min(wrapperWidth, containerHeight);
         const scale = Math.max(0.7, Math.min(1.5, dim / BASE));
 
         document.documentElement.style.setProperty('--ui-scale', scale);


### PR DESCRIPTION
## Summary
- extend mobile portrait media query to handle larger radar canvas
- allow radar canvas to overflow viewport by 20px each side in portrait

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fd16d48448325abe6707cc3dc1561