### PR TITLE
Extend mobile radar canvas

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -652,6 +652,13 @@ button.controlplay .placeholder {
     transform: translateX(-50%);
   }
 
+  @media screen and (orientation: portrait) {
+    body #radarCanvas {
+      width: calc(100vw + 40px);
+      aspect-ratio: 1 / 1;
+    }
+  }
+
   .telemetry {
     display: flex;
     flex-direction: row;

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -1522,7 +1522,12 @@ class Simulator {
     scaleUI() {
         const BASE = 900;
         const containerHeight = this.mainContainer.clientHeight;
-        const wrapperWidth = this.radarWrapper.clientWidth;
+        let wrapperWidth = this.radarWrapper.clientWidth;
+
+        if (window.matchMedia('(max-width: 792px) and (orientation: portrait)').matches) {
+            wrapperWidth = window.innerWidth + 40;
+        }
+
         const dim = Math.min(wrapperWidth, containerHeight);
         const scale = Math.max(0.7, Math.min(1.5, dim / BASE));
 


### PR DESCRIPTION
## Summary
- allow radar canvas to fill extra space in portrait mobile view
- update JS scaling logic so portrait mobile width uses `window.innerWidth + 40`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fd35bc20c8325b222e6e8e3d363f6