### PR TITLE
Fix mobile viewport centering

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -27,7 +27,7 @@ body {
   margin-left: auto;
   margin-right: auto;
   position: relative;
-  left:28px;
+  /* removed absolute offset so the canvas can center properly */
 }
 .radar {
   align-self: stretch;
@@ -643,8 +643,11 @@ button.controlplay .placeholder {
   }
 
   @media screen and (orientation: portrait) {
+    /* Center the viewport horizontally on mobile */
     .radar {
-      width: calc(100vw + 40px);
+      width: 100vw;
+      margin-left: auto;
+      margin-right: auto;
     }
 
     body #radarCanvas {


### PR DESCRIPTION
## Summary
- remove hard coded canvas offset that broke centering
- center the radar viewport when in portrait orientation on mobile

## Testing
- `npm run build` *(fails: parcel not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687fd8cd03c083259e9a308679cb8601