### PR TITLE
Fix mobile card widths

### DIFF
--- a/components/cards/cpa/style.css
+++ b/components/cards/cpa/style.css
@@ -99,7 +99,7 @@
   left: 20px;
   border-radius: var(--br-4);
   background-color: var(--color-gray);
-  width: 224px;
+  width: 196px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/components/cards/relative-motion/style.css
+++ b/components/cards/relative-motion/style.css
@@ -102,7 +102,7 @@
   left: 20px;
   border-radius: var(--br-4);
   background-color: var(--color-gray);
-  width: 224px;
+  width: 196px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;


### PR DESCRIPTION
## Summary
- keep relative motion and CPA card width consistent with ownship & track

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe26d9de08325a3c3822e4363cc10