### PR TITLE
Fix mobile widths for wide cards

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -669,7 +669,7 @@ button.controlplay .placeholder {
     width: 180px;
   }
   .card.wide {
-    width: 220px;
+    width: 180px;
   }
   
   .secondary .metric-value {


### PR DESCRIPTION
## Summary
- adjust `.card.wide` width in mobile media query to match other cards

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe6c746f88325b14299650677a3ae