### PR TITLE
Increase radar minimum size

### DIFF
--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -1523,7 +1523,7 @@ class Simulator {
         const containerHeight = this.mainContainer.clientHeight;
         const wrapperWidth = this.radarWrapper.clientWidth;
         const dim = Math.min(wrapperWidth, containerHeight);
-        const scale = Math.max(0.7, Math.min(1.5, dim / BASE));
+        const scale = Math.max(650 / BASE, Math.min(1.5, dim / BASE));
 
         document.documentElement.style.setProperty('--ui-scale', scale);
         this.uiScaleFactor = scale;
@@ -1550,7 +1550,7 @@ class Simulator {
 
     setZoom(scale) {
         const BASE = 900;
-        const clamped = Math.max(0.7, Math.min(1.5, scale));
+        const clamped = Math.max(650 / BASE, Math.min(1.5, scale));
         document.documentElement.style.setProperty('--ui-scale', clamped);
         this.uiScaleFactor = clamped;
 


### PR DESCRIPTION
## Summary
- bump the minimum scale used in `scaleUI` and `setZoom` so the radar canvas can't drop below 650px on mobile

## Testing
- `npm run build` *(fails: parcel not found)*
- `npm install` *(fails: cannot access registry)*

------
https://chatgpt.com/codex/tasks/task_e_688004c6663c83259cb34e58aee8370f