### PR TITLE
Allow radar canvas to exceed viewport

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -2,7 +2,8 @@ body {
   margin: 0;
   line-height: normal;
   height: 100vh;
-  overflow: hidden;
+  overflow-y: hidden;
+  overflow-x: auto;
 }
 
 :root {

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -1522,7 +1522,8 @@ class Simulator {
         const BASE = 900;
         const containerHeight = this.mainContainer.clientHeight;
         const wrapperWidth = this.radarWrapper.clientWidth;
-        const dim = Math.min(wrapperWidth, containerHeight);
+        const isPortrait = wrapperWidth < containerHeight;
+        const dim = isPortrait ? containerHeight : Math.min(wrapperWidth, containerHeight);
         const scale = Math.max(650 / BASE, Math.min(1.5, dim / BASE));
 
         document.documentElement.style.setProperty('--ui-scale', scale);


### PR DESCRIPTION
## Summary
- relax body overflow restrictions to allow horizontal scroll
- adapt `scaleUI` to use height when device is in portrait orientation

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_688007f495988325b2a04f417f0e5aa1