### PR TITLE
Move CPA indicator under track layer

### DIFF
--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -1112,6 +1112,9 @@ class Simulator {
         if (this.showWeather) {
             this.drawWeatherInfo(center, radius);
         }
+        if(this.showCPAInfo && this.selectedTrackId !== null) {
+            this.drawCPAIndicator(center, radius);
+        }
         this.drawOwnShipIcon(center, radius);
         this.tracks.forEach(track => {
             if (track.range > this.maxRange) return;
@@ -1120,9 +1123,6 @@ class Simulator {
                 this.drawRelativeMotionVector(center, radius, track);
             }
         });
-        if(this.showCPAInfo && this.selectedTrackId !== null) {
-            this.drawCPAIndicator(center, radius);
-        }
         if (this.selectedTrackId !== null) {
             const track = this.tracks.find(t => t.id === this.selectedTrackId);
             if (track) this.drawBearingLine(center, radius, track);


### PR DESCRIPTION
## Summary
- reorder drawing of CPA marker so it's rendered before ownship and track layers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880bc88a0248325869e135db5e61c99