### PR TITLE
Update icon and vector colors

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -756,11 +756,16 @@ button.controlplay .placeholder {
   display: none;
 }
 
-.control-forward,
-.control-backward {
-  height: 64px;
-  width: 64px;
-}
+  .control-forward,
+  .control-backward {
+    height: 64px;
+    width: 64px;
+  }
+
+  /* Ensure regenerate icon matches desktop color */
+  #regenerate svg {
+    color: var(--primary-500);
+  }
 
 }
 

--- a/css/global.css
+++ b/css/global.css
@@ -63,7 +63,7 @@ body {
   --radar-white: #FFFFFF;
   --radar-faint-green: rgba(117, 251, 76, 0.5);
   --radar-faint-white: rgba(255, 255, 255, 0.5);
-  --radar-dark-orange: #FF8C00;
+  --radar-dark-orange: #B0B0B0;
   --radar-faint-orange: rgba(255, 140, 0, 0.5);
   /* fallback for dynamic 100vh calculation */
   --vh: 1vh;


### PR DESCRIPTION
## Summary
- set radar dark orange to grey for ordered vectors
- ensure regenerate icon stays green on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688209b007508325bcff09045e4a7761