### PR TITLE
Replace orange radar color variable with grey

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -64,7 +64,7 @@ body {
   --radar-faint-green: rgba(117, 251, 76, 0.5);
   --radar-faint-white: rgba(255, 255, 255, 0.5);
   --radar-dark-grey: #B0B0B0;
-  --radar-faint-orange: rgba(255, 140, 0, 0.5);
+  --radar-faint-grey: rgba(176, 176, 176, 0.5);
   /* fallback for dynamic 100vh calculation */
   --vh: 1vh;
   /* global UI scale set by JavaScript */


### PR DESCRIPTION
## Summary
- swap `--radar-faint-orange` for `--radar-faint-grey` in CSS

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_688256ab9db48325b4685ab75f74f442