### PR TITLE
Remove vector handle circles

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -20,5 +20,5 @@ async function loadSimulator() {
 window.addEventListener('DOMContentLoaded', loadSimulator);
 
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js');
+  navigator.serviceWorker.register(new URL('/sw.js', import.meta.url));
 }

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -41,7 +41,7 @@ function solveCPA(own, tgt) {
 }
 
 const cpaWorker = typeof Worker !== 'undefined'
-  ? new Worker('./cpa-worker.js', { type: 'module' })
+  ? new Worker(new URL('./cpa-worker.js', import.meta.url), { type: 'module' })
   : null;
 
 function solveCPAAsync(own, tgt) {
@@ -1281,10 +1281,11 @@ class Simulator {
             this.ctx.moveTo(center, center);
             this.ctx.lineTo(dEndX, dEndY);
             this.ctx.stroke();
-            this.ctx.beginPath();
-            this.ctx.arc(dEndX, dEndY, handleRadius, 0, 2 * Math.PI);
-            this.ctx.fillStyle = this.radarWhite;
-            this.ctx.fill();
+            // Removed handle circle drawing for drag endpoint
+            // this.ctx.beginPath();
+            // this.ctx.arc(dEndX, dEndY, handleRadius, 0, 2 * Math.PI);
+            // this.ctx.fillStyle = this.radarWhite;
+            // this.ctx.fill();
             this.ctx.restore();
         }
 
@@ -1294,10 +1295,11 @@ class Simulator {
         this.ctx.moveTo(center, center);
         this.ctx.lineTo(endX, endY);
         this.ctx.stroke();
-        this.ctx.beginPath();
-        this.ctx.arc(endX, endY, handleRadius, 0, 2 * Math.PI);
-        this.ctx.fillStyle = this.radarGreen;
-        this.ctx.fill();
+        // Removed handle circle drawing for static endpoint
+        // this.ctx.beginPath();
+        // this.ctx.arc(endX, endY, handleRadius, 0, 2 * Math.PI);
+        // this.ctx.fillStyle = this.radarGreen;
+        // this.ctx.fill();
     }
 
     getTargetCoords(center, radius, track) {
@@ -1327,10 +1329,11 @@ class Simulator {
         this.ctx.moveTo(x, y);
         this.ctx.lineTo(endX, endY);
         this.ctx.stroke();
-        this.ctx.beginPath();
-        this.ctx.arc(endX, endY, handleRadius, 0, 2 * Math.PI);
-        this.ctx.fillStyle = this.radarGreen;
-        this.ctx.fill();
+        // Removed handle circle drawing for target vector endpoint
+        // this.ctx.beginPath();
+        // this.ctx.arc(endX, endY, handleRadius, 0, 2 * Math.PI);
+        // this.ctx.fillStyle = this.radarGreen;
+        // this.ctx.fill();
         this.ctx.font = `${Math.max(11, radius * 0.038)}px 'IBM Plex Sans Mono', monospace`;
         this.ctx.textAlign = 'left';
         this.ctx.textBaseline = 'top';


### PR DESCRIPTION
## Summary
- Remove handle circle drawing from own ship and target vectors
- Use URL-based paths for service worker and CPA worker to satisfy Parcel

## Testing
- `npm run build` *(fails: Failed to install @parcel/transformer-webmanifest: npm error 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e02dc154833281fadd3dc0f8cf85