### PR TITLE
feat: add versioned asset build script

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,11 @@
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180.png">
     <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png"/>
 
-    <link rel="stylesheet" href="./css/global.css" />
-    <link rel="stylesheet" href="./css/beta.css" />
+    <link rel="stylesheet" href="./css/global.css?v=__VERSION__" />
+    <link rel="stylesheet" href="./css/beta.css?v=__VERSION__" />
+    <link rel="modulepreload" href="./js/radar-engine.js?v=__VERSION__" />
+    <link rel="modulepreload" href="./js/object-pool.js?v=__VERSION__" />
+    <link rel="modulepreload" href="./js/cpa-worker.js?v=__VERSION__" />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=IBM Plex Mono:wght@400;500&display=swap"
@@ -266,6 +269,6 @@
       </div>
     </div>
     <div id="loading" style="display:none">Loading…</div>
-    <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/main.js?v=__VERSION__"></script>
   </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,7 @@ async function loadSimulator() {
   const loader = document.getElementById('loading');
   if (loader) loader.style.display = 'block';
   try {
-    const mod = await import('./radar-engine.js');
+    const mod = await import(`./radar-engine.js?v=__VERSION__`);
     const { Simulator } = mod;
     window.sim = new Simulator();
   } catch (err) {
@@ -20,5 +20,5 @@ async function loadSimulator() {
 window.addEventListener('DOMContentLoaded', loadSimulator);
 
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js');
+  navigator.serviceWorker.register(`/sw.js?v=__VERSION__`);
 }

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -2,8 +2,8 @@
  * Scenario generation & COLREGs contact controller
  * ============================================================
  */
-import { ObjectPool } from './object-pool.js';
-import { ViewportController } from './viewport-controller.js';
+import { ObjectPool } from './object-pool.js?v=__VERSION__';
+import { ViewportController } from './viewport-controller.js?v=__VERSION__';
 
 const trackPool = new ObjectPool(() => ({
   id: '', x: 0, y: 0, course: 0, speed: 0,
@@ -41,7 +41,7 @@ function solveCPA(own, tgt) {
 }
 
 const cpaWorker = typeof Worker !== 'undefined'
-  ? new Worker('./cpa-worker.js', { type: 'module' })
+  ? new Worker(`./cpa-worker.js?v=__VERSION__`, { type: 'module' })
   : null;
 
 function solveCPAAsync(own, tgt) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "name": "maneuver",
   "scripts": {
     "start": "parcel ./*.html ",
-   "build": "parcel build ./*.html --dist-dir ./dist"
+    "prebuild": "node scripts/set-version.js",
+    "build": "parcel build ./*.html --dist-dir ./dist"
   },
   "version": "1.0.0"
 }

--- a/scripts/set-version.js
+++ b/scripts/set-version.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function getVersion() {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch (e) {
+    const pkg = require('../package.json');
+    return pkg.version || '0.0.0';
+  }
+}
+
+const version = getVersion();
+
+const files = [
+  'index.html',
+  'sw.js',
+  path.join('js', 'main.js'),
+  path.join('js', 'radar-engine.js'),
+];
+
+files.forEach((file) => {
+  const filePath = path.resolve(__dirname, '..', file);
+  const data = fs.readFileSync(filePath, 'utf8');
+  const result = data.replace(/__VERSION__/g, version);
+  fs.writeFileSync(filePath, result);
+});
+
+console.log(`Applied version ${version} to ${files.length} files.`);

--- a/sw.js
+++ b/sw.js
@@ -1,17 +1,17 @@
 
 // Update CACHE_VERSION on each release to force old caches to clear
-const CACHE_VERSION = 'v1';
+const CACHE_VERSION = '__VERSION__';
 const CACHE_NAME = `maneuver-cache-${CACHE_VERSION}`;
 const ASSETS = [
   '/',
   '/index.html',
   '/manifest.webmanifest',
-  '/js/main.js',
-  '/js/radar-engine.js',
-  '/js/object-pool.js',
-  '/js/cpa-worker.js',
-  '/css/global.css',
-  '/css/beta.css',
+  `/js/main.js?v=${CACHE_VERSION}`,
+  `/js/radar-engine.js?v=${CACHE_VERSION}`,
+  `/js/object-pool.js?v=${CACHE_VERSION}`,
+  `/js/cpa-worker.js?v=${CACHE_VERSION}`,
+  `/css/global.css?v=${CACHE_VERSION}`,
+  `/css/beta.css?v=${CACHE_VERSION}`,
   '/offline.html',
   '/favicons.svg'
 ];


### PR DESCRIPTION
## Summary
- add build script to stamp commit hash into HTML, JS, and service worker
- version CSS and JS assets to aid cache busting
- update service worker cache naming and asset list

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to install @parcel/transformer-webmanifest: npm error code E403)*

------
https://chatgpt.com/codex/tasks/task_e_68a790ee61bc8332892fddcb0fecfaba