### PR TITLE
Remove blue background from beta stylesheet

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -598,7 +598,6 @@ button.controlplay .placeholder {
     padding-left: var(--padding-12);
     padding-right: var(--padding-12);
     padding-bottom: var(--padding-48);
-    background-color: blue;
   }
 
   .beta .maneuver-logo-child {


### PR DESCRIPTION
## Summary
- drop default blue background from beta component CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: 403 Forbidden - @parcel/transformer-webmanifest)*

------
https://chatgpt.com/codex/tasks/task_e_68a90426e3e48332a93eb56d42f9a911