### PR TITLE
Fix radar layout for small screens

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -647,13 +647,10 @@ button.controlplay .placeholder {
   }
 
   body #radarCanvas {
-    position: relative;
-    width: calc(100% + 10px);
-    max-width: none;
-    margin-left: auto;
-    margin-right: auto;
-    left: 50%;
-    transform: translateX(-50%);
+    position: absolute;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
   }
 
   .telemetry {
@@ -684,14 +681,14 @@ button.controlplay .placeholder {
     color: var(--primary-500);
     text-align: right;
   }
-  .radar {
+  /* .radar {
     min-width: 100%;
     flex: 1 1 auto;
     position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-  }
+  } */
   .card {
     flex:1;
   }


### PR DESCRIPTION
## Summary
- Ensure radar canvas remains absolutely positioned and fills viewport on small screens
- Remove mobile override of radar wrapper to keep absolute layout across breakpoints

## Testing
- ⚠️ `npm test` (missing script)
- ⚠️ `npm run build` (failed to install @parcel/transformer-webmanifest)


------
https://chatgpt.com/codex/tasks/task_e_68a91ed2c4f483328c294e1e6fcf3b7f