### PR TITLE
Remove padding in mobile beta layout

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -599,9 +599,7 @@ button.controlplay .placeholder {
   .beta{
     flex-direction: column;
     align-items: flex-end;
-    padding-left: var(--padding-12);
-    padding-right: var(--padding-12);
-    padding-bottom: var(--padding-48);
+    padding: 0;
   }
 
   .beta .maneuver-logo-child {


### PR DESCRIPTION
## Summary
- Set `.beta` container padding to `0` for mobile layouts so the canvas can span the full width.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: @parcel/transformer-webmanifest 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a91ee56b0c8332bd37a9ca174a9d4f