### PR TITLE
Adjust stroke widths for radar, ships, and controls

### DIFF
--- a/css/beta.css
+++ b/css/beta.css
@@ -86,6 +86,16 @@ button.buttonbase {
   width: 20px;
 }
 
+.radarcontrols svg path,
+.sim-controls svg path {
+  stroke-width: var(--stroke-control-outline);
+}
+
+.radarcontrols button.active svg path,
+.sim-controls button.active svg path {
+  stroke-width: var(--stroke-control-outline-active);
+}
+
 .radarcontrols,
 #radar-settings-menu {
   display: flex;

--- a/css/global.css
+++ b/css/global.css
@@ -70,4 +70,12 @@ body {
   /* global UI scale set by JavaScript */
   --ui-scale: 1;
   --base: calc(1 * var(--ui-scale));
+
+  /* Stroke widths */
+  --stroke-radar-bg: calc(1.5px * var(--ui-scale));
+  --stroke-radar-ring: calc(2.5px * var(--ui-scale));
+  --stroke-ship-outline: calc(2.5px * var(--ui-scale));
+  --stroke-ship-halo: calc(3.5px * var(--ui-scale));
+  --stroke-control-outline: calc(2px * var(--ui-scale));
+  --stroke-control-outline-active: calc(3.5px * var(--ui-scale));
 }

--- a/index.html
+++ b/index.html
@@ -14,11 +14,11 @@
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180.png">
     <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png"/>
 
-    <link rel="stylesheet" href="./css/global.css?v=__VERSION__" />
-    <link rel="stylesheet" href="./css/beta.css?v=__VERSION__" />
-    <link rel="modulepreload" href="./js/radar-engine.js?v=__VERSION__" />
-    <link rel="modulepreload" href="./js/object-pool.js?v=__VERSION__" />
-    <link rel="modulepreload" href="./js/cpa-worker.js?v=__VERSION__" />
+    <link rel="stylesheet" href="./css/global.css?v=b24a6b5" />
+    <link rel="stylesheet" href="./css/beta.css?v=b24a6b5" />
+    <link rel="modulepreload" href="./js/radar-engine.js?v=b24a6b5" />
+    <link rel="modulepreload" href="./js/object-pool.js?v=b24a6b5" />
+    <link rel="modulepreload" href="./js/cpa-worker.js?v=b24a6b5" />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=IBM Plex Mono:wght@400;500&display=swap"
@@ -133,10 +133,32 @@
               <div id="sim-clock" class="placeholder">00:01:04</div>
             </button>
             <div class="tracking">
-              <button type="button" id="past" class="control-backward" aria-label="Rewind" title="Rewind"><img class="controlbackward-icon" loading="lazy" alt="" src="./public/controlbackward.svg"/>
+              <button type="button" id="past" class="control-backward" aria-label="Rewind" title="Rewind">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+                  <g clip-path="url(#cbk)">
+                    <path d="M29.9996 19.3335V28.6668L24.6663 24.0001L29.9996 19.3335Z" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M22.6666 19.3335V28.6668L17.3333 24.0001L22.6666 19.3335Z" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                  </g>
+                  <defs>
+                    <clipPath id="cbk">
+                      <rect width="48" height="48" fill="white"/>
+                    </clipPath>
+                  </defs>
+                </svg>
                 <span id="rev-speed-indicator" class="position-absolute d-none" style="bottom:0; right:0.25rem; font-size:0.75rem;"></span>
               </button>
-              <button type="button" id="future" class="control-forward" aria-label="Fast forward" title="Fast forward"><img class="controlforward-icon" loading="lazy" alt="" src="./public/controlforward.svg"/>
+              <button type="button" id="future" class="control-forward" aria-label="Fast forward" title="Fast forward">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+                  <g clip-path="url(#cfw)">
+                    <path d="M18.75 19.3335V28.6668L24.0833 24.0001L18.75 19.3335Z" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M26.0835 19.3335V28.6668L31.4168 24.0001L26.0835 19.3335Z" fill="currentColor" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"/>
+                  </g>
+                  <defs>
+                    <clipPath id="cfw">
+                      <rect width="48" height="48" fill="white"/>
+                    </clipPath>
+                  </defs>
+                </svg>
                 <span id="ff-speed-indicator" class="position-absolute d-none" style="bottom:0; right:0.25rem; font-size:0.75rem;"></span>
               </button>
             </div>
@@ -269,6 +291,6 @@
       </div>
     </div>
     <div id="loading" style="display:none">Loading…</div>
-    <script type="module" src="js/main.js?v=__VERSION__"></script>
+    <script type="module" src="js/main.js?v=b24a6b5"></script>
   </body>
 </html>

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -32,6 +32,13 @@ const LABEL_OFFSET_PX     = 6;           // gap between ring and label
 const VECTOR_LINE_WIDTH   = 1.4 * 1.2 * 2; // consistent width for all vectors
 const VECTOR_HANDLE_RADIUS = 6;          // base radius for vector drag handles (CSS px)
 
+// Stroke widths (CSS px)
+const STROKE_RADAR_BG       = 1.5;
+const STROKE_RADAR_RING     = 2.5;
+const STROKE_SHIP_OUTLINE   = 2.5;
+const STROKE_SHIP_HALO      = 3.5;
+const STROKE_SHIP_HALO_HOVER = 2.5;
+
 function solveCPA(own, tgt) {
     const rx = tgt.x - own.x;
     const ry = tgt.y - own.y;
@@ -1237,10 +1244,10 @@ class Simulator {
         if (this.selectedTrackId !== null) {
             const track = this.tracks.find(t => t.id === this.selectedTrackId);
             if (track) this.drawBearingLine(center, radius, track);
-            this.drawSelectionIndicator(center, radius, this.selectedTrackId, this.radarWhite, 1.5);
+            this.drawSelectionIndicator(center, radius, this.selectedTrackId, this.radarWhite, STROKE_SHIP_HALO * this.DPR);
         }
         if (this.hoveredTrackId !== null && this.hoveredTrackId !== this.selectedTrackId) {
-            this.drawSelectionIndicator(center, radius, this.hoveredTrackId, this.radarFaintWhite, 1);
+            this.drawSelectionIndicator(center, radius, this.hoveredTrackId, this.radarFaintWhite, STROKE_SHIP_HALO_HOVER * this.DPR);
         }
 
         this.ctx.restore();
@@ -1257,7 +1264,7 @@ class Simulator {
         ctx.fillStyle = '#000000';
         ctx.fillRect(0, 0, width, height);
         ctx.strokeStyle = this.radarFaintGreen;
-        ctx.lineWidth = 2.7;
+        ctx.lineWidth = STROKE_RADAR_RING * this.DPR;
 
         ctx.beginPath();
         ctx.arc(center.x, center.y, radius, 0, 2 * Math.PI);
@@ -1309,7 +1316,7 @@ class Simulator {
 
     drawRangeRings(center, radius) {
         this.ctx.strokeStyle = this.radarFaintGreen;
-        this.ctx.lineWidth = 2.7;
+        this.ctx.lineWidth = STROKE_RADAR_RING * this.DPR;
         this.ctx.beginPath();
         this.ctx.arc(center.x, center.y, radius, 0, 2 * Math.PI);
         this.ctx.stroke();
@@ -1426,7 +1433,7 @@ class Simulator {
         const { x, y } = this.getTargetCoords(center, radius, track);
         const targetSize = Math.max(11, radius * 0.038);
         this.ctx.strokeStyle = this.radarGreen;
-        this.ctx.lineWidth = 1.8;
+        this.ctx.lineWidth = STROKE_SHIP_OUTLINE * this.DPR;
         this.ctx.strokeRect(x - targetSize / 2, y - targetSize / 2, targetSize, targetSize);
         this.ctx.lineWidth = VECTOR_LINE_WIDTH;
         const timeInHours = this.vectorTimeInMinutes / 60;
@@ -1492,7 +1499,7 @@ class Simulator {
         this.ctx.fill();
         this.ctx.save();
         this.ctx.strokeStyle = this.radarFaintGreen;
-        this.ctx.lineWidth = 1;
+        this.ctx.lineWidth = STROKE_RADAR_BG * this.DPR;
         this.ctx.setLineDash([2, 3]);
         this.ctx.beginPath();
         this.ctx.moveTo(center.x, center.y);
@@ -1505,7 +1512,7 @@ class Simulator {
         const { x, y } = this.getTargetCoords(center, radius, track);
         this.ctx.save();
         this.ctx.strokeStyle = this.radarWhite;
-        this.ctx.lineWidth = 1;
+        this.ctx.lineWidth = STROKE_RADAR_BG * this.DPR;
         this.ctx.setLineDash([2, 4]);
         this.ctx.beginPath();
         this.ctx.moveTo(center.x, center.y);


### PR DESCRIPTION
## Summary
- add CSS variables for radar, ship, and control stroke widths
- scale canvas strokes with device pixel ratio and use new constants
- inline playback control SVGs to apply stroke width variables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to install @parcel/transformer-webmanifest: npm error E403)*

------
https://chatgpt.com/codex/tasks/task_e_68a921ce44288332b52942309ec1e127