### PR TITLE
Fix cache busting placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,11 +14,11 @@
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180.png">
     <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png"/>
 
-    <link rel="stylesheet" href="./css/global.css?v=b24a6b5" />
-    <link rel="stylesheet" href="./css/beta.css?v=b24a6b5" />
-    <link rel="modulepreload" href="./js/radar-engine.js?v=b24a6b5" />
-    <link rel="modulepreload" href="./js/object-pool.js?v=b24a6b5" />
-    <link rel="modulepreload" href="./js/cpa-worker.js?v=b24a6b5" />
+    <link rel="stylesheet" href="./css/global.css?v=__VERSION__" />
+    <link rel="stylesheet" href="./css/beta.css?v=__VERSION__" />
+    <link rel="modulepreload" href="./js/radar-engine.js?v=__VERSION__" />
+    <link rel="modulepreload" href="./js/object-pool.js?v=__VERSION__" />
+    <link rel="modulepreload" href="./js/cpa-worker.js?v=__VERSION__" />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=IBM Plex Mono:wght@400;500&display=swap"
@@ -291,6 +291,6 @@
       </div>
     </div>
     <div id="loading" style="display:none">Loading…</div>
-    <script type="module" src="js/main.js?v=b24a6b5"></script>
+    <script type="module" src="js/main.js?v=__VERSION__"></script>
   </body>
 </html>

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -2,8 +2,8 @@
  * Scenario generation & COLREGs contact controller
  * ============================================================
  */
-import { ObjectPool } from './object-pool.js?v=87ab9a6';
-import { ViewportController } from './viewport-controller.js?v=87ab9a6';
+import { ObjectPool } from './object-pool.js?v=__VERSION__';
+import { ViewportController } from './viewport-controller.js?v=__VERSION__';
 
 const trackPool = new ObjectPool(() => ({
   id: '',
@@ -54,7 +54,7 @@ function solveCPA(own, tgt) {
 }
 
 const cpaWorker = typeof Worker !== 'undefined'
-  ? new Worker(`./cpa-worker.js?v=87ab9a6`, { type: 'module' })
+  ? new Worker(`./cpa-worker.js?v=__VERSION__`, { type: 'module' })
   : null;
 
 function solveCPAAsync(own, tgt) {


### PR DESCRIPTION
## Summary
- Replace hard-coded asset hashes in `index.html` with a dynamic `__VERSION__` placeholder
- Use `__VERSION__` placeholder for module imports and worker script in `js/radar-engine.js`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: 403 Forbidden when installing @parcel/transformer-webmanifest)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b603bd10833294971f7443237f6b