### PR TITLE
fix: handle cache-busting URLs

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -34,17 +34,20 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   const { request } = event;
-  const url = request.url;
+  const url = new URL(request.url);
 
-  if (request.method === 'GET' && (url.endsWith('.css') || url.endsWith('.js'))) {
+  if (
+    request.method === 'GET' &&
+    (url.pathname.endsWith('.css') || url.pathname.endsWith('.js'))
+  ) {
     event.respondWith(
       fetch(request)
-        .then(networkResponse => {
-          return caches.open(CACHE_NAME).then(cache => {
+        .then(networkResponse =>
+          caches.open(CACHE_NAME).then(cache => {
             cache.put(request, networkResponse.clone());
             return networkResponse;
-          });
-        })
+          })
+        )
         .catch(() => caches.match(request))
     );
   } else {


### PR DESCRIPTION
## Summary
- handle cache-busting query parameters in service worker fetch handler

## Testing
- `rg -n "background[^;]*blue" -t css`
- `node scripts/set-version.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9b7786ca4833284bb66de66600b19