### PR TITLE
Remove service worker script reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,6 @@
     </div>
     <script src="js/arena.js"></script>
     <script src="js/main.js"></script>
-    <script src="js/service-worker.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         window.sim = new Simulator(document.getElementById('radarCanvas'));


### PR DESCRIPTION
## Summary
- remove service worker script tag from index.html to rely on service worker registration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Registering service workers with a string literal is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dc79e3208332a2c2108651ef166d