### PR TITLE
Ensure TypeForm loads before simulator

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,8 +269,19 @@
     <script src="js/main.js"></script>
     <script src="js/service-worker.js"></script>
     <script>
-      document.addEventListener('DOMContentLoaded', () => {
+      function loadSimulator() {
         window.sim = new Simulator(document.getElementById('radarCanvas'));
+      }
+
+      document.addEventListener('DOMContentLoaded', () => {
+        if (window.TypeForm) {
+          loadSimulator();
+        } else {
+          const script = document.createElement('script');
+          script.src = 'https://embed.typeform.com/embed.js';
+          script.onload = loadSimulator;
+          document.head.appendChild(script);
+        }
       });
     </script>
   </body>

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/js/service-worker.js');
+    navigator.serviceWorker.register(new URL('./service-worker.js', window.location.href));
   });
 }
 


### PR DESCRIPTION
## Summary
- Dynamically register service worker with URL resolution
- Load TypeForm script before initializing simulator

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to install @parcel/transformer-webmanifest)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dc7d5d8c833289178507bd211ffa