### PR TITLE
fix: add version flag to scenario config

### DIFF
--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -16,6 +16,7 @@ const trackPool = new ObjectPool(() => ({
   keyframes: [],
 }));
 const ScenarioConfig = {
+    v                    : 1,
     contact_density        : 6,
     cpa_leeway             : 0.3,
     time_to_cpa_range      : [15, 30],


### PR DESCRIPTION
## Summary
- include a version field in the scenario configuration so header reads succeed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1e767e9b883329cff38f80442c6f7