### PR TITLE
Add unit tests for simulator loading and initialization

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,23 +3,27 @@
  * Dynamically loads heavy modules to improve PWA install performance.
  */
 
-async function loadSimulator() {
+export async function loadSimulator(importer = (path) => import(path)) {
   const loader = document.getElementById('loading');
+  const errorEl = document.getElementById('load-error');
   if (loader) loader.style.display = 'block';
+  if (errorEl) errorEl.textContent = '';
   try {
-    const mod = await import(`./radar-engine.js?v=__VERSION__`);
+    const mod = await importer(`./radar-engine.js?v=__VERSION__`);
     const { Simulator } = mod;
     window.sim = new Simulator();
   } catch (err) {
     console.error('Failed to load simulator module', err);
+    if (errorEl) errorEl.textContent = 'Failed to load simulator';
   } finally {
     if (loader) loader.style.display = 'none';
   }
 }
 
-window.addEventListener('DOMContentLoaded', loadSimulator);
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => loadSimulator());
+}
 
-if ('serviceWorker' in navigator) {
+if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   navigator.serviceWorker.register(`/sw.js?v=__VERSION__`);
-
 }

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -290,14 +290,15 @@ class Simulator {
         this.uiUpdatePending = false;
         // --- DOM Element References ---
         this.canvas = document.getElementById('radarCanvas');
-        this.ctx = this.canvas.getContext('2d');
-        
         if (!this.canvas) {
             console.error('radarCanvas element not found in DOM');
+            return;
         }
+        this.ctx = this.canvas.getContext('2d');
         console.log('Simulator init: 2D context:', this.ctx);
         if (!this.ctx) {
             console.error('Failed to get 2D context for radarCanvas');
+            return;
         }
         this.dragTooltip = document.getElementById('drag-tooltip');
         this.orderTooltip = document.getElementById('order-tooltip');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "start": "parcel ./*.html ",
     "prebuild": "node scripts/set-version.js",
-    "build": "parcel build ./*.html --dist-dir ./dist"
+    "build": "parcel build ./*.html --dist-dir ./dist",
+    "test": "node --test"
   },
   "version": "1.0.0"
 }

--- a/test/main.test.mjs
+++ b/test/main.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const loader = { style: { display: 'none' } };
+const errorEl = { textContent: '' };
+
+global.document = {
+  getElementById: (id) => {
+    if (id === 'loading') return loader;
+    if (id === 'load-error') return errorEl;
+    return null;
+  }
+};
+
+global.window = { addEventListener: () => {} };
+global.navigator = {};
+
+const { loadSimulator } = await import('../js/main.js');
+
+test('loadSimulator initializes Simulator and toggles loader', async () => {
+  class FakeSimulator {}
+  const importer = async () => ({ Simulator: FakeSimulator });
+  await loadSimulator(importer);
+  assert.equal(loader.style.display, 'none');
+  assert.equal(errorEl.textContent, '');
+  assert.ok(window.sim instanceof FakeSimulator);
+});
+
+test('loadSimulator surfaces error message on failure', async () => {
+  const importer = async () => { throw new Error('network'); };
+  let errorLogged = false;
+  const origError = console.error;
+  console.error = () => { errorLogged = true; };
+  await loadSimulator(importer);
+  console.error = origError;
+  assert.equal(loader.style.display, 'none');
+  assert.equal(errorEl.textContent, 'Failed to load simulator');
+  assert.ok(errorLogged);
+});

--- a/test/simulator.test.mjs
+++ b/test/simulator.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function dummyEl() {
+  return { style: {}, open: false };
+}
+
+// Shared stubs
+const baseDoc = {
+  querySelector: () => dummyEl(),
+  documentElement: dummyEl()
+};
+
+global.getComputedStyle = () => ({ getPropertyValue: () => '' });
+
+test('logs error when canvas element missing', async () => {
+  global.document = { ...baseDoc, getElementById: () => null };
+  global.window = { devicePixelRatio: 1 };
+  let messages = [];
+  const orig = console.error;
+  console.error = (msg) => messages.push(msg);
+  const { Simulator } = await import('../js/radar-engine.js');
+  new Simulator();
+  console.error = orig;
+  assert.ok(messages.includes('radarCanvas element not found in DOM'));
+});
+
+test('logs error when canvas context unavailable', async () => {
+  const canvas = { getContext: () => null };
+  global.document = {
+    ...baseDoc,
+    getElementById: (id) => (id === 'radarCanvas' ? canvas : dummyEl())
+  };
+  global.window = { devicePixelRatio: 1 };
+  let messages = [];
+  const orig = console.error;
+  console.error = (msg) => messages.push(msg);
+  const { Simulator } = await import('../js/radar-engine.js');
+  new Simulator();
+  console.error = orig;
+  assert.ok(messages.includes('Failed to get 2D context for radarCanvas'));
+});


### PR DESCRIPTION
## Summary
- export `loadSimulator` and surface user-visible load errors
- guard against missing radar canvas in `Simulator`
- add Node-based unit tests for loader and canvas checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1eb52e0188332ad72028dc8ca8127