### PR TITLE
Handle service worker registration failures

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -20,5 +20,7 @@ async function loadSimulator() {
 window.addEventListener('DOMContentLoaded', loadSimulator);
 
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js');
+  navigator.serviceWorker
+    .register('/sw.js')
+    .catch(err => console.error('SW registration failed', err));
 }


### PR DESCRIPTION
## Summary
- log failures when registering the service worker

## Testing
- `npm test` (fails: Missing script "test")
- `node -e "global.document={getElementById:()=>null}; global.window={addEventListener:()=>{}}; global.navigator={serviceWorker:{register:()=>Promise.reject(new Error('missing'))}}; require('./js/main.js');"`

------
https://chatgpt.com/codex/tasks/task_e_68b9fdb254fc8332a176724d24693929