### PR TITLE
Handle offline fetch failures in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -34,6 +34,9 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(resp => resp || fetch(event.request))
+    caches.match(event.request).then(resp => {
+      if (resp) return resp;
+      return fetch(event.request).catch(() => caches.match('/offline.html'));
+    })
   );
 });


### PR DESCRIPTION
## Summary
- Add offline fallback in service worker fetch handler to respond with cached offline page when network requests fail.

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: Registering service workers with a string literal is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fdc53e14833299d36fbdcc8e09ab