### PR TITLE
Handle JS and CSS requests with network-first caching

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -20,5 +20,7 @@ async function loadSimulator() {
 window.addEventListener('DOMContentLoaded', loadSimulator);
 
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js');
+  navigator.serviceWorker
+    .register('/sw.js')
+    .catch(err => console.error('SW registration failed', err));
 }

--- a/sw.js
+++ b/sw.js
@@ -34,6 +34,9 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(resp => resp || fetch(event.request))
+    caches.match(event.request).then(resp => {
+      if (resp) return resp;
+      return fetch(event.request).catch(() => caches.match('/offline.html'));
+    })
   );
 });

--- a/sw.js
+++ b/sw.js
@@ -33,10 +33,26 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (url.pathname.endsWith('.js') || url.pathname.endsWith('.css')) {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request).then(resp => {
+    caches.match(request).then(resp => {
       if (resp) return resp;
-      return fetch(event.request).catch(() => caches.match('/offline.html'));
+      return fetch(request).catch(() => caches.match('/offline.html'));
     })
   );
 });


### PR DESCRIPTION
## Summary
- Detect `.js` and `.css` fetches in the service worker
- Use a network-first strategy that caches successful responses and falls back to cache on failure
- Preserve cache-first behavior and precaching for other assets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Registering service workers with a string literal is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0c78d5ac83328b80831088f83add