### PR TITLE
refactor: register service worker relative to module

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -19,6 +19,7 @@ async function loadSimulator() {
 
 window.addEventListener('DOMContentLoaded', loadSimulator);
 
+// Register service worker relative to this module
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker
     .register(new URL('../sw.js', import.meta.url))

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -39,7 +39,7 @@ function solveCPA(own, tgt) {
 }
 
 const cpaWorker = typeof Worker !== 'undefined'
-  ? new Worker('./cpa-worker.js', { type: 'module' })
+  ? new Worker(new URL('./cpa-worker.js', import.meta.url), { type: 'module' })
   : null;
 
 function solveCPAAsync(own, tgt) {


### PR DESCRIPTION
## Summary
- ensure service worker registration uses module-relative URL
- load CPA worker via module-relative URL for bundler compatibility

## Testing
- `npm run build` *(fails: 403 Forbidden retrieving @parcel/transformer-webmanifest)*

------
https://chatgpt.com/codex/tasks/task_e_68bf360a13c8833287adfb8e0309d8c8