### PR TITLE
build hashed assets into service worker

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "",
-  "outputDirectory": ".",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "headers": [
     {
       "source": "/manifest.webmanifest",


### PR DESCRIPTION
## Summary
- dynamically generate service worker cache list based on built assets and cache version
- configure Vercel to build into `dist` with `npm run build`

## Testing
- `npm run build` *(fails: Failed to install @parcel/transformer-webmanifest: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf39eaf85c83329a229cc19cdd84ad