### PR TITLE
build hashed assets into service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ Desktop.ini # Windows desktop icon settings
 
 # Others
 *.log   # Log files
+
+# Build artifacts
+node_modules/
+dist/
+.parcel-cache/

--- a/.parcelrc
+++ b/.parcelrc
@@ -1,0 +1,11 @@
+{
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "*.webmanifest": ["@parcel/transformer-raw"],
+    "webmanifest:*.{json,webmanifest}": ["@parcel/transformer-raw"]
+  },
+  "packagers": {
+    "*.webmanifest": "@parcel/packager-raw",
+    "*.{jsonld,svg,webmanifest}": "@parcel/packager-raw"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <title>Maneuver : Simulator : Beta</title>
 
     <link rel="icon" type="image/svg+xml" href="favicons.svg">
-    <link rel="manifest" href="manifest.webmanifest"/>
+    <link rel="manifest" href="/manifest.webmanifest" data-parcel-ignore/>
     <link rel="apple-touch-icon" sizes="180x180" href="icon-180.png">
     <link rel="icon" type="image/png" sizes="192x192" href="./icon-192.png"/>
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "name": "maneuver",
   "scripts": {
     "start": "parcel ./*.html",
-    "build": "parcel build ./*.html --dist-dir ./dist && node scripts/set-sw-cache-version.js",
+    "build": "parcel build ./*.html --dist-dir ./dist --no-autoinstall && cp manifest.webmanifest dist/ && node scripts/set-sw-cache-version.js",
     "test": "node --test"
   },
   "version": "1.0.0"

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "",
-  "outputDirectory": ".",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "headers": [
     {
       "source": "/manifest.webmanifest",


### PR DESCRIPTION
## Summary
- dynamically generate service worker cache list based on built assets and cache version
- configure Vercel to build into `dist` with `npm run build`
- copy `manifest.webmanifest` into `dist` and bypass Parcel's webmanifest transformer

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf39eaf85c83329a229cc19cdd84ad