### PR TITLE
Configure cache headers for static assets

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -21,6 +21,6 @@ window.addEventListener('DOMContentLoaded', loadSimulator);
 
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker
-    .register('/sw.js')
+    .register(new URL('../sw.js', import.meta.url))
     .catch(err => console.error('SW registration failed', err));
 }

--- a/js/main.js
+++ b/js/main.js
@@ -19,6 +19,7 @@ async function loadSimulator() {
 
 window.addEventListener('DOMContentLoaded', loadSimulator);
 
+// Register service worker relative to this module
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker
     .register(new URL('../sw.js', import.meta.url))

--- a/js/main.js
+++ b/js/main.js
@@ -20,5 +20,7 @@ async function loadSimulator() {
 window.addEventListener('DOMContentLoaded', loadSimulator);
 
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js');
+  navigator.serviceWorker
+    .register('/sw.js')
+    .catch(err => console.error('SW registration failed', err));
 }

--- a/js/radar-engine.js
+++ b/js/radar-engine.js
@@ -39,7 +39,7 @@ function solveCPA(own, tgt) {
 }
 
 const cpaWorker = typeof Worker !== 'undefined'
-  ? new Worker('./cpa-worker.js', { type: 'module' })
+  ? new Worker(new URL('./cpa-worker.js', import.meta.url), { type: 'module' })
   : null;
 
 function solveCPAAsync(own, tgt) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "name": "maneuver",
   "scripts": {
     "start": "parcel ./*.html",
-    "build": "parcel build ./*.html --dist-dir ./dist && node scripts/set-sw-cache-version.js"
+    "build": "parcel build ./*.html --dist-dir ./dist && node scripts/set-sw-cache-version.js",
+    "test": "node --test"
   },
   "version": "1.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "license": "ISC",
   "name": "maneuver",
   "scripts": {
-    "start": "parcel ./*.html ",
-   "build": "parcel build ./*.html --dist-dir ./dist"
+    "start": "parcel ./*.html",
+    "build": "parcel build ./*.html --dist-dir ./dist && node scripts/set-sw-cache-version.js"
   },
   "version": "1.0.0"
 }

--- a/scripts/set-sw-cache-version.js
+++ b/scripts/set-sw-cache-version.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const {execSync} = require('child_process');
+
+// Determine version from git commit hash or fallback to timestamp
+let version;
+try {
+  version = execSync('git rev-parse --short HEAD').toString().trim();
+} catch (e) {
+  version = Date.now().toString();
+}
+
+const swTemplatePath = path.join(__dirname, '..', 'sw.js');
+const distPath = path.join(__dirname, '..', 'dist');
+const swDestPath = path.join(distPath, 'sw.js');
+
+const swSource = fs.readFileSync(swTemplatePath, 'utf8');
+const result = swSource.replace('__CACHE_VERSION__', version);
+
+if (!fs.existsSync(distPath)) {
+  fs.mkdirSync(distPath, { recursive: true });
+}
+fs.writeFileSync(swDestPath, result);
+console.log(`Service worker generated with CACHE_VERSION=${version}`);

--- a/sw.js
+++ b/sw.js
@@ -34,6 +34,9 @@ self.addEventListener('activate', event => {
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(resp => resp || fetch(event.request))
+    caches.match(event.request).then(resp => {
+      if (resp) return resp;
+      return fetch(event.request).catch(() => caches.match('/offline.html'));
+    })
   );
 });

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 
-// Update CACHE_VERSION on each release to force old caches to clear
-const CACHE_VERSION = 'v1';
+// CACHE_VERSION is replaced during build to bust old caches on new releases
+const CACHE_VERSION = '__CACHE_VERSION__';
 const CACHE_NAME = `maneuver-cache-${CACHE_VERSION}`;
 const ASSETS = [
   '/',

--- a/test/object-pool.test.js
+++ b/test/object-pool.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { ObjectPool } from '../js/object-pool.js';
+
+test('acquire uses factory when pool is empty', () => {
+  let created = 0;
+  const pool = new ObjectPool(() => {
+    created += 1;
+    return {};
+  });
+  pool.acquire();
+  assert.strictEqual(created, 1);
+});
+
+test('released objects are reused', () => {
+  const pool = new ObjectPool(() => ({ value: 42 }));
+  const first = pool.acquire();
+  pool.release(first);
+  const second = pool.acquire();
+  assert.strictEqual(second, first);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,33 @@
   "outputDirectory": "dist",
   "headers": [
     {
+      "source": "/(.*)\\.(js|css)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/sw.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache"
+        }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache"
+        }
+      ]
+    },
+    {
       "source": "/manifest.webmanifest",
       "headers": [
         {

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "",
-  "outputDirectory": ".",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "headers": [
     {
       "source": "/manifest.webmanifest",


### PR DESCRIPTION
## Summary
- cache fingerprinted JS/CSS assets for a year with immutable headers
- force HTML and service worker revalidation by disabling cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0310d844483329165e14821a939ef