### PR TITLE
Use import.meta.url for simulator module path

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -7,8 +7,9 @@ async function loadSimulator() {
   const loader = document.getElementById('loading');
   if (loader) loader.style.display = 'block';
   try {
-    const mod = await import('./radar-engine.js');
-    const { Simulator } = mod;
+    const { Simulator } = await import(
+      new URL('./radar-engine.js', import.meta.url).href
+    );
     window.sim = new Simulator();
   } catch (err) {
     console.error('Failed to load simulator module', err);


### PR DESCRIPTION
## Summary
- load radar engine using a URL based on `import.meta.url`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0681480f88332a287fb1bcfd291c4