### PR TITLE
Add Instrument UI redesign prototype

### DIFF
--- a/docs/superpowers/plans/2026-03-28-remove-gap-runner.md
+++ b/docs/superpowers/plans/2026-03-28-remove-gap-runner.md
@@ -1,0 +1,770 @@
+# Remove Gap Runner Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove all Gap Runner game mode code, leaving only the Simulator mode.
+
+**Architecture:** Gap Runner is woven through 4 source files (`js/main.js`, `js/arena.js`, `index.html`, `css/beta.css`). The removal touches: mode selection UI, HUD/overlay HTML, CSS styling, GameManager routing, Simulator constructor state, initialization branching, the `generateTSS()` method, game loop integration, scoring/penalty/level/damage methods, commit button logic, TSS rendering, and the `btnScen` click handler's gap_runner branch. After removal, the app should auto-start in Simulator mode with no menu screen, or keep the menu with only the Simulator button.
+
+**Tech Stack:** Vanilla JavaScript, HTML5, CSS3, Parcel bundler
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `js/main.js` | Remove `startGapRunner`, `btnGapRunner`, and `gap_runner` URL param handling |
+| Modify | `js/arena.js` | Remove Gap Runner state, `loadGapRunnerScenario`, `checkGapRunnerStatus`, `completeLevel`, `gameOver`, `applyPenalty`, `flashDamage`, `updateGapRunnerHUD`, `triggerDamageOverlay`, `startCommit`, `stopCommit`, `generateTSS`, `drawTSS`, `drawWaypoint`, TSS rendering block, and all `gap_runner` mode conditionals |
+| Modify | `index.html` | Remove Gap Runner button, HUD div, damage overlay, level overlay, game-over overlay |
+| Modify | `css/beta.css` | Remove `.hud`, `.damage-overlay`, `.level-overlay`, `.gap-runner-active` rules |
+| Modify | `CLAUDE.md` | Remove Gap Runner references from architecture docs |
+
+---
+
+### Task 1: Create feature branch
+
+- [ ] **Step 1: Create and switch to a new branch**
+
+```bash
+git checkout -b remove-gap-runner
+```
+
+- [ ] **Step 2: Verify branch**
+
+```bash
+git branch --show-current
+```
+
+Expected: `remove-gap-runner`
+
+---
+
+### Task 2: Remove Gap Runner HTML elements from `index.html`
+
+**Files:**
+- Modify: `index.html:307` (Gap Runner button)
+- Modify: `index.html:312-318` (HUD + damage overlay)
+- Modify: `index.html:320-335` (level overlay + game-over overlay)
+
+- [ ] **Step 1: Remove the Gap Runner menu button**
+
+In `index.html`, remove this line:
+
+```html
+        <button id="btn-gap-runner" class="menu-button">Gap Runner</button>
+```
+
+- [ ] **Step 2: Remove the Gap Runner HUD div**
+
+Remove this block (lines 312-316):
+
+```html
+  <div id="gap-runner-hud" class="hud hidden">
+    <div class="hud-row"><span class="hud-label">Level: </span><span id="hud-level">1</span></div>
+    <div class="hud-row"><span class="hud-label">Score: </span><span id="hud-score">0</span></div>
+    <div class="hud-row"><span class="hud-label">Time: </span><span id="hud-time">00:00</span></div>
+  </div>
+```
+
+- [ ] **Step 3: Remove the damage overlay**
+
+Remove this line (318):
+
+```html
+  <div id="damage-overlay" class="damage-overlay hidden"></div>
+```
+
+- [ ] **Step 4: Remove the level-complete overlay**
+
+Remove this block (lines 320-325):
+
+```html
+  <div id="level-overlay" class="level-overlay hidden">
+    <div class="menu-content">
+      <h1 class="menu-title">Level Complete</h1>
+      <div id="level-message" style="color: var(--primary-500); font-family: 'IBM Plex Mono'; font-size: 1.5rem;"></div>
+    </div>
+  </div>
+```
+
+- [ ] **Step 5: Remove the game-over overlay**
+
+Remove this block (lines 327-335):
+
+```html
+  <div id="game-over-overlay" class="level-overlay hidden">
+    <div class="menu-content">
+      <h1 class="menu-title" style="color: var(--radar-dark-orange);">Game Over</h1>
+      <div id="game-over-message"
+        style="color: white; font-family: 'IBM Plex Mono'; font-size: 1.5rem; margin-bottom: 2rem;">Collision Detected
+      </div>
+      <button id="btn-restart" class="menu-button">Return to Menu</button>
+    </div>
+  </div>
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add index.html
+git commit -m "feat: remove Gap Runner HTML elements (button, HUD, overlays)"
+```
+
+---
+
+### Task 3: Remove Gap Runner CSS from `css/beta.css`
+
+**Files:**
+- Modify: `css/beta.css:920-921` (level-overlay hidden rule — shared with main-menu)
+- Modify: `css/beta.css:926-939` (level-overlay base rule)
+- Modify: `css/beta.css:997-1063` (HUD, damage-overlay, gap-runner-active styles)
+- Modify: `css/beta.css:1083-1243` (mobile portrait + landscape gap-runner-active overrides)
+
+- [ ] **Step 1: Remove `.level-overlay.hidden` from the shared hidden rule**
+
+The rule at line 920 is:
+
+```css
+.main-menu.hidden,
+.level-overlay.hidden {
+```
+
+Change it to just:
+
+```css
+.main-menu.hidden {
+```
+
+- [ ] **Step 2: Remove the `.level-overlay` base rule**
+
+Remove lines 926-939:
+
+```css
+.level-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.85);
+  /* Slightly transparent */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  opacity: 1;
+  transition: opacity 0.3s ease-in-out;
+}
+```
+
+- [ ] **Step 3: Remove the Gap Runner HUD & Overlay CSS block**
+
+Remove everything from the `/* --- Gap Runner HUD & Overlay --- */` comment (line 997) through the `.gap-runner-active #future, .gap-runner-active #past` rule (line 1063). This includes:
+- `.hud` styles (lines 997-1018)
+- `.hud-row` (lines 1020-1024)
+- `.damage-overlay` and variants (lines 1026-1045)
+- Mobile gap-runner tweaks (lines 1047-1057)
+- `.gap-runner-active #future, .gap-runner-active #past` (lines 1059-1063)
+
+- [ ] **Step 4: Remove all mobile portrait `gap-runner-active` rules**
+
+Remove lines 1083-1158 (all `body.mobile-portrait.gap-runner-active` selectors).
+
+- [ ] **Step 5: Remove all mobile landscape `gap-runner-active` rules**
+
+Remove lines 1173-1243 (all `body.mobile-landscape.gap-runner-active` selectors).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add css/beta.css
+git commit -m "feat: remove Gap Runner CSS (HUD, overlays, mobile overrides)"
+```
+
+---
+
+### Task 4: Remove Gap Runner from `js/main.js`
+
+**Files:**
+- Modify: `js/main.js`
+
+- [ ] **Step 1: Remove Gap Runner references from GameManager**
+
+Replace the entire `GameManager` class with this cleaned version that removes `btnGapRunner`, `startGapRunner`, and the `gap_runner` URL param branch:
+
+```javascript
+class GameManager {
+  constructor() {
+    this.menuOverlay = document.getElementById('main-menu');
+    this.btnSimulator = document.getElementById('btn-simulator');
+
+    // Bind methods
+    this.startSimulatorMode = this.startSimulatorMode.bind(this);
+
+    this._attachListeners();
+    this._checkURLParams();
+  }
+
+  _attachListeners() {
+    this.btnSimulator?.addEventListener('click', this.startSimulatorMode);
+
+    // Main Menu navigation via Logo
+    const logo = document.querySelector('.maneuverlogo');
+    if (logo) {
+      logo.style.cursor = 'pointer';
+      logo.addEventListener('click', () => {
+        this.showMenu();
+        if (window.sim && window.sim.isSimulationRunning) {
+          window.sim.togglePlayPause();
+        }
+      });
+    }
+  }
+
+  _checkURLParams() {
+    const params = new URLSearchParams(window.location.search);
+    const mode = params.get('mode');
+
+    if (mode === 'simulator') {
+      this.startSimulatorMode();
+    }
+  }
+
+  hideMenu() {
+    this.menuOverlay.classList.add('hidden');
+  }
+
+  showMenu() {
+    this.menuOverlay.classList.remove('hidden');
+  }
+
+  startSimulatorMode() {
+    this.hideMenu();
+    this.initSimulator({ mode: 'simulator' });
+  }
+
+  initSimulator(config) {
+    if (window.sim) {
+      window.sim.destroy();
+    }
+
+    if (document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(() => {
+        window.sim = new Simulator(config);
+      });
+    } else {
+      window.sim = new Simulator(config);
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add js/main.js
+git commit -m "feat: remove Gap Runner from GameManager"
+```
+
+---
+
+### Task 5: Remove Gap Runner from `js/arena.js` — Constructor & State
+
+**Files:**
+- Modify: `js/arena.js:349-369` (Gap Runner overlay refs + state in constructor block 1)
+- Modify: `js/arena.js:426-459` (Gap Runner state block 2 + hudElements)
+
+- [ ] **Step 1: Remove Gap Runner overlay DOM refs (lines 349-373)**
+
+Remove this block from the constructor:
+
+```javascript
+        // --- Gap Runner Overlays ---
+        this.levelOverlay = document.getElementById('level-overlay');
+        this.levelMessage = document.getElementById('level-message');
+        this.gameOverOverlay = document.getElementById('game-over-overlay');
+        this.gameOverMessage = document.getElementById('game-over-message');
+        this.btnRestart = document.getElementById('btn-restart');
+
+        // Gap Runner State
+        this.gapRunnerScore = 0;
+        this.currentLevelScore = 0;
+        this.levelStartTime = 0;
+        this.penaltyRegistry = new Set();
+
+        // Gap Runner DOM Container (Consolidated)
+        this.hudElements = {
+            container: document.getElementById('gap-runner-hud'),
+            level: document.getElementById('hud-level'),
+            score: document.getElementById('hud-score'),
+            time: document.getElementById('hud-time'),
+            damageOverlay: document.getElementById('damage-overlay')
+        };
+
+        this.btnRestart?.addEventListener('click', () => {
+            location.reload();
+        });
+```
+
+- [ ] **Step 2: Remove Gap Runner state block 2 (lines 426-459)**
+
+Remove this block (everything between `orderedVectorEndpoint` closing brace and `this.tracks = [`):
+
+```javascript
+        // --- Gap Runner State ---
+        this.gapRunnerScore = 0;
+        // Initialize Score for this level
+        this.currentLevelScore = 5000;
+        this.penaltyRegistry = new Set();
+        this.perfectGapRegistry = new Set();
+
+        // Combo / "Clean Wake" Tracking
+        this.isCommitting = false;
+        this.laneChangeCount = 0;
+        this.lanesCrossed = 0;
+        // Determine initial lane index (based on y position approx)
+        // Lanes are approx 3nm wide zones?
+        // Let's define zones:
+        // Zone 0: South Start (y < -4)
+        // Zone 1: Westbound Lane (y: -4 to -1)
+        // Zone 2: Separation (y: -1 to 1)
+        // Zone 3: Eastbound Lane (y: 1 to 4)
+        // Zone 4: North Goal (y > 4)
+        this.lastLaneIndex = 0; // Start at South
+        this.lastOrderedCourse = this.ownShip.orderedCourse;
+
+        // UI Setup
+        this.btnPast.classList.add('hidden');
+        this.btnFuture.classList.add('hidden');
+        if (this.btnCommit) this.btnCommit.classList.add('hidden');
+
+        this.hudElements = {
+            container: document.getElementById('gap-runner-hud'),
+            level: document.getElementById('hud-level'),
+            score: document.getElementById('hud-score'),
+            time: document.getElementById('hud-time'),
+            damageOverlay: document.getElementById('damage-overlay')
+        };
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/arena.js
+git commit -m "feat: remove Gap Runner state and DOM refs from Simulator constructor"
+```
+
+---
+
+### Task 6: Remove Gap Runner from `js/arena.js` — Initialization & Scenario Loading
+
+**Files:**
+- Modify: `js/arena.js:537-540` (`_initialize` gap_runner branch)
+- Modify: `js/arena.js:582-635` (`loadGapRunnerScenario` method)
+
+- [ ] **Step 1: Simplify `_initialize` method**
+
+Replace the mode conditional:
+
+```javascript
+        if (this.config.mode === 'gap_runner') {
+            this.loadGapRunnerScenario(1);
+        } else {
+            document.body.classList.remove('gap-runner-active');
+            this.addTrack();
+            this.addTrack();
+        }
+```
+
+With just the simulator initialization:
+
+```javascript
+        this.addTrack();
+        this.addTrack();
+```
+
+- [ ] **Step 2: Remove the entire `loadGapRunnerScenario` method**
+
+Remove the method from `loadGapRunnerScenario(level = 1) {` through its closing `}` (lines 582-635).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/arena.js
+git commit -m "feat: remove loadGapRunnerScenario and gap_runner init branch"
+```
+
+---
+
+### Task 7: Remove Gap Runner from `js/arena.js` — Event Handlers
+
+**Files:**
+- Modify: `js/arena.js:751-763` (`btnScen` click handler gap_runner branch)
+- Modify: `js/arena.js:929-931` (`destroy` method gap-runner cleanup)
+
+- [ ] **Step 1: Simplify `btnScen` click handler**
+
+Replace the entire `btnScen` event listener:
+
+```javascript
+        this.btnScen?.addEventListener('click', () => {
+            if (this.config.mode === 'gap_runner') {
+                // GAP RUNNER: Restart from Level 1
+                this.loadGapRunnerScenario(1);
+
+                // Ensure simulation resumes if it was paused or game over
+                if (!this.isSimulationRunning) {
+                    this.isSimulationRunning = true;
+                    this.btnPlayPause.classList.remove('pause');
+                    this.startGameLoop();
+                    // Update speed indicator to normal 1x just in case
+                    this.simulationSpeed = 1;
+                    this.updateSpeedIndicator();
+                }
+            } else {
+                // SIMULATOR: Generate new scenario (preserve current config)
+                const currentConfig = this.config;
+                window.sim.destroy();
+                window.sim = new Simulator(currentConfig);
+            }
+        });
+```
+
+With just the simulator branch:
+
+```javascript
+        this.btnScen?.addEventListener('click', () => {
+            const currentConfig = this.config;
+            window.sim.destroy();
+            window.sim = new Simulator(currentConfig);
+        });
+```
+
+- [ ] **Step 2: Remove gap-runner cleanup from `destroy()` method**
+
+Remove these lines from the `destroy()` method:
+
+```javascript
+        // Cleanup UI
+        document.body.classList.remove('gap-runner-active');
+        this.hudElements?.container?.classList.add('hidden');
+        this.hudElements?.damageOverlay?.classList.remove('active');
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/arena.js
+git commit -m "feat: remove Gap Runner from event handlers and destroy method"
+```
+
+---
+
+### Task 8: Remove Gap Runner from `js/arena.js` — Game Logic Methods
+
+**Files:**
+- Modify: `js/arena.js:1201-1477` (all Gap Runner game logic methods)
+- Modify: `js/arena.js:1257-1260` (`updatePhysics` gap_runner branch)
+
+- [ ] **Step 1: Remove gap_runner check from `updatePhysics`**
+
+Remove this block from `updatePhysics`:
+
+```javascript
+        if (this.config.mode === 'gap_runner') {
+            this.checkGapRunnerStatus(deltaTime);
+            if (!this.isSimulationRunning) return;
+        }
+```
+
+- [ ] **Step 2: Remove `startCommit` method**
+
+Remove the entire method (lines 1233-1240):
+
+```javascript
+    startCommit() {
+        if (this.config.mode !== 'gap_runner') return;
+        if (!this.isSimulationRunning) this.togglePlayPause();
+        this.simulationSpeed = 50;
+        this.isCommitting = true;
+        this.updateButtonStyles();
+        this.markSceneDirty();
+    }
+```
+
+- [ ] **Step 3: Remove `stopCommit` method**
+
+Remove the entire method (lines 1245-1251):
+
+```javascript
+    stopCommit() {
+        if (this.config.mode !== 'gap_runner') return;
+        this.simulationSpeed = 1;
+        this.isCommitting = false;
+        this.updateButtonStyles();
+        this.markSceneDirty();
+    }
+```
+
+- [ ] **Step 4: Remove the first `updateGapRunnerHUD` method (lines 1201-1213)**
+
+```javascript
+    updateGapRunnerHUD() {
+        if (!this.hudElements.score) return;
+
+        // Total Score = Banked Score + Current Level Projected Score
+        const total = Math.floor(this.gapRunnerScore + this.currentLevelScore);
+        this.hudElements.score.textContent = total.toLocaleString();
+
+        const now = performance.now();
+        const elapsed = Math.floor((now - this.levelStartTime) / 1000);
+        const mm = Math.floor(elapsed / 60).toString().padStart(2, '0');
+        const ss = (elapsed % 60).toString().padStart(2, '0');
+        this.hudElements.time.textContent = `${mm}:${ss}`;
+    }
+```
+
+- [ ] **Step 5: Remove `triggerDamageOverlay` method (lines 1215-1228)**
+
+```javascript
+    triggerDamageOverlay() {
+        const ov = this.hudElements.damageOverlay;
+        if (!ov) return;
+        ov.classList.remove('hidden');
+        // Force reflow
+        void ov.offsetWidth;
+        ov.classList.add('active');
+
+        // Remove after short flash
+        setTimeout(() => {
+            ov.classList.remove('active');
+            setTimeout(() => ov.classList.add('hidden'), 300); // Wait for transition
+        }, 500);
+    }
+```
+
+- [ ] **Step 6: Remove `checkGapRunnerStatus` method (lines 1297-1408)**
+
+Remove the entire method from `checkGapRunnerStatus(deltaTime) {` through its closing `}`.
+
+- [ ] **Step 7: Remove `applyPenalty` method (lines 1410-1414)**
+
+```javascript
+    applyPenalty(trackId, amount) {
+        this.penaltyRegistry.add(trackId);
+        this.currentLevelScore = Math.max(0, this.currentLevelScore - amount);
+        this.flashDamage();
+        this.updateGapRunnerHUD();
+    }
+```
+
+- [ ] **Step 8: Remove `flashDamage` method (lines 1417-1430)**
+
+```javascript
+    flashDamage() {
+        if (!this.hudElements.damageOverlay) return;
+        this.hudElements.damageOverlay.classList.remove('hidden');
+        // Trigger reflow
+        void this.hudElements.damageOverlay.offsetWidth;
+        this.hudElements.damageOverlay.classList.add('active');
+
+        setTimeout(() => {
+            this.hudElements.damageOverlay.classList.remove('active');
+            setTimeout(() => {
+                this.hudElements.damageOverlay.classList.add('hidden');
+            }, 300); // Wait for transition
+        }, 300); // 300ms flash
+    }
+```
+
+- [ ] **Step 9: Remove second `updateGapRunnerHUD` method (lines 1432-1443)**
+
+```javascript
+    updateGapRunnerHUD() {
+        if (!this.hudElements.score) return;
+
+        // Total Score = Banked Score + Current Level Projected Score
+        const total = Math.floor(this.gapRunnerScore + this.currentLevelScore);
+        this.hudElements.score.textContent = total.toLocaleString();
+
+        const now = performance.now();
+        const elapsed = Math.floor((now - this.levelStartTime) / 1000);
+        const mm = Math.floor(elapsed / 60).toString().padStart(2, '0');
+        const ss = (elapsed % 60).toString().padStart(2, '0');
+        this.hudElements.time.textContent = `${mm}:${ss}`;
+    }
+```
+
+- [ ] **Step 10: Remove `completeLevel` method (lines 1446-1468)**
+
+```javascript
+    completeLevel() {
+        this.isSimulationRunning = false;
+
+        // Calculate "Clean Wake" Bonus
+        let multiplier = 1;
+        if (this.laneChangeCount <= 2) {
+            multiplier = 1.5;
+            this.currentLevelScore = Math.floor(this.currentLevelScore * multiplier);
+        }
+
+        this.gameManager.showLevelOverlay(`Level ${this.currentLevel} Complete!\nScore: ${this.currentLevelScore}\n(Multiplier: x${multiplier})`);
+
+        // Add to total gap runner score
+        this.gapRunnerScore += this.currentLevelScore;
+
+        // Increase level
+        this.currentLevel++;
+        setTimeout(() => {
+            document.getElementById('level-overlay').classList.add('hidden');
+            this.loadGapRunnerScenario(this.currentLevel);
+            this.isSimulationRunning = true; // Wait for scenario load roughly? Or strict timing
+        }, 3000);
+    }
+```
+
+- [ ] **Step 11: Remove `gameOver` method (lines 1470-1476)**
+
+```javascript
+    gameOver() {
+        this.isSimulationRunning = false;
+        // this.gapRunnerActive = false; // Keep active so we don't return to sim mode, just stuck in game over
+        if (this.gameOverOverlay) {
+            this.gameOverOverlay.classList.remove('hidden');
+        }
+    }
+```
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add js/arena.js
+git commit -m "feat: remove Gap Runner game logic methods from Simulator"
+```
+
+---
+
+### Task 9: Remove Gap Runner from `js/arena.js` — TSS Rendering & ScenarioGenerator
+
+**Files:**
+- Modify: `js/arena.js:150-228` (`generateTSS` method in ScenarioGenerator)
+- Modify: `js/arena.js:230-235` (`_spawnSimple` helper — keep only if used by `makeScenario`)
+- Modify: `js/arena.js:1596-1602` (TSS rendering block in `drawRadar`)
+- Modify: `js/arena.js:1640-1679` (`drawTSS` and `drawWaypoint` methods)
+
+- [ ] **Step 1: Remove the `generateTSS` method from ScenarioGenerator**
+
+Remove the entire `generateTSS(level)` method (lines 150-228).
+
+- [ ] **Step 2: Check if `_spawnSimple` is used outside `generateTSS`**
+
+Search for `_spawnSimple` in arena.js. If it is only used by `generateTSS`, remove it too (lines 230-235).
+
+- [ ] **Step 3: Remove TSS rendering block from `drawRadar`**
+
+Remove this block:
+
+```javascript
+        // --- TSS Rendering ---
+        if (this.tssData) {
+            this.drawTSS(center, radius);
+            if (this.tssData.waypoint) {
+                this.drawWaypoint(center, radius);
+            }
+        }
+```
+
+- [ ] **Step 4: Remove `drawTSS` method (lines 1640-1662)**
+
+Remove the entire method.
+
+- [ ] **Step 5: Remove `drawWaypoint` method (lines 1665-1679+)**
+
+Remove the entire method.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/arena.js
+git commit -m "feat: remove generateTSS, drawTSS, drawWaypoint from arena.js"
+```
+
+---
+
+### Task 10: Remove commit button Gap Runner logic from `js/arena.js`
+
+**Files:**
+- Modify: `js/arena.js:728-746` (commit button event listeners)
+
+- [ ] **Step 1: Remove commit button event listeners**
+
+The commit button (`btnCommit`) with its `startCommit`/`stopCommit` handlers is Gap Runner-only. Remove the entire block that sets up the commit button listeners (the `if (this.btnCommit)` block with `mousedown`, `touchstart`, `mouseup`, `touchend`, `mouseleave` handlers).
+
+- [ ] **Step 2: Remove `btnCommit` DOM reference**
+
+Find and remove `this.btnCommit = document.getElementById('commit-btn');` from the constructor.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/arena.js
+git commit -m "feat: remove commit button Gap Runner logic"
+```
+
+---
+
+### Task 11: Clean up remaining Gap Runner references
+
+- [ ] **Step 1: Search for any remaining gap runner references**
+
+```bash
+grep -rn -i "gap.runner\|gap_runner\|gapRunner\|GapRunner\|tssData\|gapRunnerScore\|gapRunnerActive\|gapRunnerLevel\|currentLevelScore\|penaltyRegistry\|perfectGapRegistry\|laneChangeCount\|lanesCrossed\|lastLaneIndex\|hudElements\|levelOverlay\|gameOverOverlay\|btnRestart\|isCommitting\|damage-overlay\|level-overlay\|game-over" js/ css/ index.html CLAUDE.md
+```
+
+Fix any remaining references found.
+
+- [ ] **Step 2: Update CLAUDE.md**
+
+Remove references to Gap Runner mode. Update the "Two Application Modes" section to reflect that the app is now Simulator-only. Remove the Gap Runner bullet point and simplify the mode description.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "feat: clean up remaining Gap Runner references"
+```
+
+---
+
+### Task 12: Verify the app runs correctly
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+npm start
+```
+
+- [ ] **Step 2: Open http://localhost:1234 in a browser and verify:**
+
+- Main menu shows only "Simulator" button (no "Gap Runner")
+- Clicking Simulator launches the radar simulation normally
+- No console errors related to missing Gap Runner elements
+- Regenerate button works (creates new scenario)
+- Play/pause, fast-forward, rewind all work
+- Track selection and data panels work
+
+- [ ] **Step 3: Search for any remaining dead code**
+
+```bash
+grep -rn "gap\|hud\|damage\|gameOver\|levelOver\|tss\|waypoint\|commit" js/arena.js | grep -iv "comment\|committed"
+```
+
+Review output and remove any orphaned references.
+
+- [ ] **Step 4: Final commit if needed**
+
+```bash
+git add -A
+git commit -m "fix: clean up any remaining dead Gap Runner code"
+```

--- a/docs/superpowers/specs/2026-04-17-maneuver-ui-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-17-maneuver-ui-redesign-design.md
@@ -1,0 +1,173 @@
+# Maneuver UI Redesign — "Instrument" Direction
+
+**Status:** design approved · working prototype at `prototypes/redesign/`
+**Date:** 2026-04-17
+
+## Purpose
+
+Redesign the Maneuver simulator UI to better serve its stated goal: *help sailors build mental models and instincts around relative motion through a ship's radar display.* The current UI buries the single signal that teaches collision geometry (bearing drift) in 12px body text, and boxes every metric in its own card. The redesign elevates threat awareness, consolidates data onto shared surfaces, and establishes a responsive foundation that works from a pocket phone up to a wardroom desktop.
+
+The logo is preserved unchanged per user direction.
+
+## Scope
+
+**In scope:** visual direction, foundation tokens, responsive layout (desktop / tablet / mobile), information architecture of the telemetry panel, interaction model, and a working sandbox prototype with ported physics.
+
+**Out of scope (deferred):** drill mode, coach mode, settings redesign, main-menu redesign, accessibility audit beyond focus styles, production migration of `js/arena.js`.
+
+## Direction: "Instrument"
+
+One of three directions presented (*Horizon*, *Studio*, *Instrument*). User chose *Instrument*: neutral near-black surface where typography does the work, one saturated accent reserved strictly for risk-relevant moments.
+
+## Foundation
+
+### Palette
+
+| Token | Hex | Role |
+|---|---|---|
+| `ink` | `#0B0C0E` | Canvas / deepest background |
+| `ink-2` | `#101218` | Telemetry panel surface |
+| `steel` | `#151821` | Inline pill / chip backgrounds |
+| `hull` | `#2A2E38` | Dividers and 1-px rules |
+| `fog` | `#8A8E97` | Secondary text, inactive labels |
+| `bone` | `#F2F0EA` | Primary text (warm off-white) |
+| `bone-dim` | `#C9C7C1` | Tertiary / dim text |
+| `flare` | `#FF6B2C` | **Sole accent** — risk only (CPA warning, selected-risk ring, CBDR state) |
+| `radar-green` | `#75FB4C` | Ownship vector, outer range ring |
+| `radar-green-dim` | `#4A9C2E` | Inner range rings and grid |
+
+Orange is chosen for its physical-world lineage (life rings, hi-vis PPE, maritime dayshapes). Never used on chrome, buttons, or decorative surfaces.
+
+### Typography
+
+- Display / UI: **Inter** (500/600/700), fallback IBM Plex Sans.
+- Body / labels: **IBM Plex Sans** 400/500.
+- Telemetry readouts: **IBM Plex Mono** 500, `font-variant-numeric: tabular-nums`.
+- Scale: 9 / 10 / 11 / 13 / 16 / 20 / 28 / 32 px.
+- Labels: uppercase, 10–11 px, letter-spacing 0.14em, color `fog`.
+
+### Spacing & Motion
+
+- Spacing: 4 / 8 / 12 / 16 / 24 / 40 / 72 px.
+- Motion: 140–200ms on `cubic-bezier(0.2, 0.8, 0.2, 1)`. Mechanical, not bouncy.
+
+## Layout Architecture
+
+CSS grid. Three breakpoints, one spatial logic. Radar is the hero at every size.
+
+- **Desktop (≥1280):** two-row grid. Columns `64px rail · minmax(0,1fr) stage/transport · 340px panel`. Rail and panel span both rows; radar occupies the top row of the middle column; transport sits in the bottom row of the middle column.
+- **Tablet (900–1279):** same grid, narrower columns: `56px rail · 1fr stage/transport · 320px panel`.
+- **Mobile (≤900):** one-column, four-row grid in reading order: `topbar · stage (1fr) · panel (max 38dvh) · transport`. Transport is pinned to the viewport bottom for thumb reach; the panel becomes a horizontal scroll-snap deck of three cards (Track · Contacts · Ownship) and each card scrolls vertically internally. Transport bottom padding respects `env(safe-area-inset-bottom)` for iPhone home-indicator clearance.
+
+Below 420 px, the speed chips collapse and the scrubber takes the full second row of the transport.
+
+## Information Hierarchy
+
+Anchored on one insight: **bearing drift is the single signal that teaches collision geometry.** Everything else is supporting evidence.
+
+### Panel structure
+
+1. **Track header** — tag + one-word state (`bearing steady` / `risk of collision` / `past CPA`). Color goes `flare` when risk.
+2. **CBDR strip** — one row: state chip (`CBDR / STEADY / DRIFT L / DRIFT R / PAST`), 60-second bearing sparkline, and drift value (`0.2°/60s`). Whole strip goes `flare` when risk; `bone-dim` when steady but safe; `fog` when drifting normally.
+3. **Hero row** — CPA distance (orange), TCPA, and a 56-px aspect dial with text readout (`Red 42°`). No card containers — raw typography.
+4. **Data grid (4×2)** — Brg, Rng, Crs, Spd, Rel Dir, Rel Spd, Brg Rate, Tgt Ang. Course and Speed are click-to-edit.
+5. **Contacts** — compact monospace rows sorted by TCPA ascending. Click a row or a contact dot on the radar to promote.
+6. **Ownship** — single footer row, course and speed click-to-edit.
+
+Sections are separated by 1-px horizontal rules, not borders.
+
+### Radar
+
+- Polar grid, range rings at 3/6/12/24 NM, 30° bearing spokes.
+- Cardinals N/E/S/W; `N` in `bone`, others in `fog`.
+- Ownship: filled chevron + green vector sized to speed.
+- Contacts: history trails (10-sample), course vector with arrowhead, dashed CPA line + X marker on risk tracks, dashed selection ring on active track.
+- Contact labels placed outboard of the dot.
+
+## Physics Engine
+
+Ported from `js/arena.js` into `prototypes/redesign/sim.js`:
+
+- `solveCPA(own, tgt)` — identical formulation, returns `{tCPA, dCPA, xCPA, yCPA}` in world units.
+- Bearing / range from differential position.
+- Relative motion vector, speed, direction.
+- Target angle (aspect): `(bearing + 180 - track.course) mod 360`.
+- Bearing rate: `(dx·relVy − dy·relVx) / range²` in rad/hr, converted to °/min.
+- Position integration via simple Euler: `pos += vel · dt`.
+
+CBDR classification (risk): `dCPA < 1.0 NM AND 0 < tcpa < 15 min`.
+Steady-bearing classification: `|bearingRate| < 0.2 °/min AND NOT hasPassed`.
+
+Not ported (deferred):
+- Nomoto steering dynamics (`js/dynamics.js`) — the sandbox uses instantaneous course change for now; for drill mode, Nomoto will matter.
+- `ScenarioGenerator` — sandbox seeds one hand-tuned scenario at load.
+- `ContactController` COLREGs AI — contacts hold course/speed until edited by the user.
+
+## Interactions (all built and working)
+
+- **Long-press to drop contact:** 450 ms hold on the radar → ghost appears at that bearing/range → drag to set course vector → release to commit with default speed of 10 kt.
+- **Tap to select:** tap any contact dot on the radar, or click any row in the contacts list.
+- **Edit ownship course/speed:** click the underlined values in the footer. Inline popover appears; Enter applies, Esc cancels.
+- **Edit track course/speed:** click Crs or Spd in the data grid. Same popover.
+- **Range cycle:** Range pill in top-right of radar cycles 3 → 6 → 12 → 24 NM.
+- **Play / pause:** round button in transport bar.
+- **Speed chips:** 1× 2× 4× 8× multiplier on sim time.
+- **Clear contacts:** X button on rail (desktop) / topbar (mobile).
+- **Scrubber:** currently visual-only (advances with sim time, 20-min window). True seek-back requires a history buffer and is deferred.
+
+## What was removed as extraneous
+
+- Modes nav (Sandbox / Drills / Coach disabled items) — rail is now just logo + clear button.
+- Stage-head breadcrumb and meta strip.
+- Layers button (no-op).
+- Radar hint copy.
+- Vessel class descriptor.
+- Aspect-note text ("target's port bow toward us").
+- `GIVE WAY` badge — replaced with color-coded track state text.
+- Wind section (keeps sandbox focused on relative motion, not sailing).
+
+## Prototype files
+
+```
+prototypes/redesign/
+  index.html    structure
+  styles.css    full foundation and responsive layout
+  sim.js        physics engine and state store
+  radar.js      canvas renderer (reads sim state)
+  app.js        driver loop, panel rendering, interactions
+```
+
+Served locally with `python3 -m http.server 8765` at `http://localhost:8765/prototypes/redesign/`. `file://` does not work — browsers treat file URLs as unique origins, blocking cross-file coordination.
+
+## Migration Plan (for production)
+
+Four bounded steps, each a self-contained PR:
+
+1. **Tokens** — replace `css/global.css` variables with the new palette and scale. Preserve `--radar-green` so `arena.js` keeps working.
+2. **Chrome** — replace `index.html` layout and the chrome portion of `css/beta.css` with the new grid and components.
+3. **Panel rewrite** — replace the five telemetry cards with the consolidated panel structure. Update `_updateData*` methods in `arena.js` to write to the new DOM IDs.
+4. **Interactions** — add long-press-to-drop; move range/settings into the new overlay locations; replace rewind/FF with the scrubber (which will require a history buffer for true seek).
+
+No physics changes required. The prototype's `sim.js` is a simplified subset of `arena.js` — production keeps the existing physics.
+
+## Known Deviations from Paper Guide
+
+Default to dark mode despite Paper's "default light" guidance. Radar displays are dark by tradition and necessity (night vision on the bridge). A future sunlight/outdoor palette is noted for daylight mobile use.
+
+## Open Questions
+
+- **Sunlight palette** — warm cream ground, inverted accent, preserved phosphor green. Needs design when mobile outdoor use is validated.
+- **Aspect dial interaction** — currently read-only. Could become scrubbable ("what if target were Green 30° instead?").
+- **Bearing sparkline resolution** — fixed 60s window now; production should expose 30s / 60s / 3min.
+- **Scrubber history buffer** — deferred; needed for true seek-back.
+- **Haptics** — long-press-to-drop and contact-selection are natural haptic moments on mobile.
+
+## Acceptance
+
+- ✅ Foundation (palette, type, spacing, motion) approved.
+- ✅ Layout architecture (3 breakpoints) approved.
+- ✅ Information hierarchy and interaction changes approved.
+- ✅ Prototype renders at all three breakpoints; transport stays visible; radar remains hero.
+- ✅ Physics engine ported and tied to the panel + radar.
+- ✅ Long-press, inline edits, play/pause, speed, range, and contact selection all working against the live simulation.
+- Spec reviewed by user (pending).

--- a/prototypes/redesign/app.js
+++ b/prototypes/redesign/app.js
@@ -1,0 +1,426 @@
+/* =========================================================
+   App wiring — simulation loop, interactions, panel updates.
+   ========================================================= */
+
+(function () {
+  const { Sim, aspectLabel, norm360 } = window.Maneuver;
+  const sim = new Sim();
+  window.RadarView.attach(sim);
+
+  // --- Panel element cache ------------------------------------
+  const el = {
+    // track
+    tag: document.getElementById('track-tag'),
+    state: document.getElementById('track-state'),
+    trackSection: document.getElementById('track-hero'),
+
+    cbdr: document.getElementById('cbdr-strip'),
+    cbdrState: document.getElementById('cbdr-state'),
+    cbdrSpark: document.getElementById('cbdr-spark-path'),
+    cbdrDelta: document.getElementById('cbdr-delta'),
+
+    cpaRng: document.getElementById('cpa-rng-val'),
+    cpaTime: document.getElementById('cpa-time'),
+    aspectWedge: document.getElementById('aspect-wedge'),
+    aspectVal: document.getElementById('aspect-val'),
+
+    dBrg: document.getElementById('d-brg'),
+    dRng: document.getElementById('d-rng'),
+    dCrs: document.getElementById('d-crs'),
+    dSpd: document.getElementById('d-spd'),
+    dRdir: document.getElementById('d-rdir'),
+    dRspd: document.getElementById('d-rspd'),
+    dBrate: document.getElementById('d-brate'),
+    dTang: document.getElementById('d-tang'),
+
+    list: document.getElementById('contact-list'),
+    count: document.getElementById('contact-count'),
+    contactsSection: document.querySelector('.contacts'),
+
+    ownCrs: document.getElementById('own-crs'),
+    ownSpd: document.getElementById('own-spd'),
+
+    clock: document.getElementById('sim-clock'),
+    play: document.getElementById('play-btn'),
+    speeds: document.querySelectorAll('.speed'),
+    scrubFill: document.getElementById('scrub-fill'),
+    scrubHead: document.getElementById('scrub-head'),
+
+    rangeBtn: document.getElementById('range-pill'),
+    rangeVal: document.getElementById('range-val'),
+
+    clearBtn: document.getElementById('clear-btn'),
+    clearMobile: document.getElementById('clear-btn-mobile'),
+
+    editPop: document.getElementById('edit-pop'),
+    editInput: document.getElementById('edit-pop-input'),
+    editLabel: document.getElementById('edit-pop-label'),
+  };
+
+  // --- Formatters ---------------------------------------------
+  const fmtBrg = (d) => String(Math.round(norm360(d))).padStart(3, '0') + '°';
+  const fmtRng = (nm) => nm.toFixed(1);
+  const fmtSpd = (kt) => String(Math.round(kt));
+  const fmtCrs = (d) => String(Math.round(norm360(d))).padStart(3, '0');
+
+  function fmtClock(seconds) {
+    const s = Math.max(0, Math.floor(seconds));
+    const h = String(Math.floor(s / 3600)).padStart(2, '0');
+    const m = String(Math.floor((s % 3600) / 60)).padStart(2, '0');
+    const sec = String(s % 60).padStart(2, '0');
+    return `${h}:${m}:${sec}`;
+  }
+
+  function fmtTcpa(sec) {
+    if (!isFinite(sec) || sec < 0) return '—';
+    const m = Math.floor(sec / 60);
+    const s = Math.floor(sec % 60);
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  }
+
+  // --- Panel updates ------------------------------------------
+  function renderPanel() {
+    // Clock
+    el.clock.textContent = fmtClock(sim.time);
+    // Scrub fill based on 20-min window
+    const pct = Math.min(100, (sim.time / (20 * 60)) * 100);
+    el.scrubFill.style.setProperty('--pct', pct + '%');
+    el.scrubHead.style.setProperty('--pct', pct + '%');
+
+    // Ownship
+    el.ownCrs.textContent = fmtCrs(sim.own.course);
+    el.ownSpd.textContent = fmtSpd(sim.own.speed);
+
+    // Contact list
+    renderContactList();
+
+    // Active track
+    const c = sim.getActive();
+    if (!c || !c.derived) {
+      renderEmptyTrack();
+      return;
+    }
+    renderActiveTrack(c);
+  }
+
+  function renderContactList() {
+    el.count.textContent = sim.contacts.length;
+    document.body.classList.toggle('has-contacts', sim.contacts.length > 0);
+
+    // Sort by tcpa ascending (risk / future-cpa first)
+    const rows = [...sim.contacts].sort((a, b) => {
+      const ta = a.derived?.tcpaSec ?? Infinity;
+      const tb = b.derived?.tcpaSec ?? Infinity;
+      const fa = ta < 0 ? Infinity : ta;
+      const fb = tb < 0 ? Infinity : tb;
+      return fa - fb;
+    });
+
+    el.list.innerHTML = rows.map((c) => {
+      const d = c.derived || {};
+      const risk = d.isRisk;
+      const active = c.id === sim.activeId;
+      const cpaRng = isFinite(d.cpaRange) && !d.hasPassed ? d.cpaRange.toFixed(1) : '—';
+      const cpaT = fmtTcpa(d.tcpaSec);
+      return `
+        <li class="contact ${active ? 'is-active' : ''}" data-id="${c.id}">
+          <span class="contact__dot ${risk ? 'contact__dot--risk' : ''}"></span>
+          <span class="contact__tag">${c.id}</span>
+          <span class="contact__brg">${fmtBrg(d.bearing || 0)}</span>
+          <span class="contact__rng">${fmtRng(d.range || 0)}</span>
+          <span class="contact__cpa"><span class="cpa-val">${cpaRng}</span><span class="cpa-t">${cpaT}</span></span>
+        </li>
+      `;
+    }).join('');
+  }
+
+  function renderEmptyTrack() {
+    el.trackSection.classList.remove('is-risk');
+    el.tag.textContent = '—';
+    el.state.textContent = '';
+    el.cbdr.setAttribute('data-state', 'idle');
+    el.cbdrState.textContent = '—';
+    el.cbdrDelta.innerHTML = '—<span class="u">/m</span>';
+    el.cbdrSpark.setAttribute('points', '');
+    el.cpaRng.textContent = '—';
+    el.cpaTime.textContent = '—';
+    el.aspectWedge.setAttribute('d', '');
+    el.aspectVal.textContent = '—';
+    for (const k of ['dBrg', 'dRng', 'dCrs', 'dSpd', 'dRdir', 'dRspd', 'dBrate', 'dTang']) {
+      el[k].textContent = '—';
+    }
+  }
+
+  function renderActiveTrack(c) {
+    const d = c.derived;
+    el.tag.textContent = c.id;
+    el.trackSection.classList.toggle('is-risk', !!d.isRisk);
+    el.state.textContent = d.hasPassed ? 'past CPA'
+                         : d.isRisk ? 'risk of collision'
+                         : d.isSteady ? 'bearing steady' : '';
+
+    // CBDR
+    const { drift, series } = sim.bearingDrift(c, 60);
+    if (series.length >= 2) {
+      const ys = series.map(s => s.brg);
+      const min = Math.min(...ys);
+      const max = Math.max(...ys);
+      const span = Math.max(0.5, max - min);
+      const pts = series.map((s, i) => {
+        const x = (i / (series.length - 1)) * 120;
+        const y = 18 - ((s.brg - min) / span) * 16;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      }).join(' ');
+      el.cbdrSpark.setAttribute('points', pts);
+    } else {
+      el.cbdrSpark.setAttribute('points', '');
+    }
+
+    const cbdrMode = d.hasPassed ? 'idle' : d.isRisk ? 'risk' : d.isSteady ? 'steady' : 'drifting';
+    el.cbdr.setAttribute('data-state', cbdrMode);
+    el.cbdrState.textContent = d.hasPassed ? 'PAST'
+                             : d.isRisk ? 'CBDR'
+                             : d.isSteady ? 'STEADY'
+                             : drift > 0 ? 'DRIFT R' : 'DRIFT L';
+    const absDrift = Math.abs(drift).toFixed(1);
+    el.cbdrDelta.innerHTML = `${absDrift}°<span class="u">/60s</span>`;
+
+    // Hero numbers
+    el.cpaRng.textContent = d.hasPassed ? '—' : d.cpaRange.toFixed(1);
+    el.cpaTime.textContent = d.hasPassed ? '—' : fmtTcpa(d.tcpaSec);
+
+    // Aspect dial: wedge from 0° to targetAngle
+    if (!d.hasPassed) {
+      const ta = d.targetAngle;
+      const rad = (ta - 90) * Math.PI / 180; // 0°=top
+      const large = ta > 180 ? 1 : 0;
+      const ex = 42 * Math.cos(rad);
+      const ey = 42 * Math.sin(rad);
+      el.aspectWedge.setAttribute('d',
+        `M0,0 L0,-42 A42,42 0 ${large},1 ${ex.toFixed(2)},${ey.toFixed(2)} Z`);
+      el.aspectVal.textContent = aspectLabel(ta);
+    } else {
+      el.aspectWedge.setAttribute('d', '');
+      el.aspectVal.textContent = '—';
+    }
+
+    // Data grid
+    el.dBrg.textContent = fmtBrg(d.bearing);
+    el.dRng.textContent = fmtRng(d.range);
+    el.dCrs.textContent = fmtCrs(c.course);
+    el.dSpd.textContent = fmtSpd(c.speed);
+    el.dRdir.textContent = d.relDir == null ? '—' : fmtBrg(d.relDir);
+    el.dRspd.textContent = d.relSpd.toFixed(1);
+    el.dBrate.innerHTML =
+      d.bearingRateWord === 'STEADY' ? '0.0<span class="cell__u">/m</span>'
+      : `${Math.abs(d.bearingRateDpm).toFixed(2)}<span class="cell__u">${d.bearingRateWord}</span>`;
+    el.dTang.textContent = aspectLabel(d.targetAngle);
+  }
+
+  // --- Driver loop (rAF) --------------------------------------
+  let last = performance.now();
+  function frame(now) {
+    const dt = Math.min(0.1, (now - last) / 1000);
+    last = now;
+    sim.tick(dt);
+    requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+
+  // --- Subscribe panel to sim changes -------------------------
+  sim.on(renderPanel);
+
+  // Initial seed: starboard cross (risk), port crosser, overtaken target
+  sim.addContact({ bearing: 45,  range: 4.0, course: 270, speed: 14 });
+  sim.addContact({ bearing: 330, range: 8.0, course: 150, speed: 10 });
+  sim.addContact({ bearing: 10,  range: 3.0, course: 0,   speed: 6  });
+
+  // --- Controls -----------------------------------------------
+  el.play.addEventListener('click', () => {
+    sim.toggle();
+    el.play.classList.toggle('is-playing', sim.playing);
+  });
+
+  el.speeds.forEach((b) => {
+    b.addEventListener('click', () => {
+      el.speeds.forEach((x) => { x.classList.remove('is-active'); x.setAttribute('aria-checked', 'false'); });
+      b.classList.add('is-active');
+      b.setAttribute('aria-checked', 'true');
+      sim.setSpeed(parseInt(b.dataset.speed, 10));
+    });
+  });
+
+  const RANGES = [3, 6, 12, 24];
+  el.rangeBtn.addEventListener('click', () => {
+    const i = RANGES.indexOf(window.RadarView.getRange());
+    const next = RANGES[(i + 1) % RANGES.length];
+    el.rangeVal.textContent = next;
+    window.RadarView.setRange(next);
+  });
+
+  const doClear = () => sim.clearContacts();
+  el.clearBtn?.addEventListener('click', doClear);
+  el.clearMobile?.addEventListener('click', doClear);
+
+  // --- Contact selection --------------------------------------
+  el.list.addEventListener('click', (e) => {
+    const li = e.target.closest('.contact');
+    if (li) sim.setActive(li.dataset.id);
+  });
+
+  // --- Long-press + drag on canvas ----------------------------
+  const canvas = window.RadarView.canvas;
+  const LONG_PRESS_MS = 450;
+  const MOVE_CANCEL_PX = 8;
+  let press = null;
+
+  function pointerPos(e) {
+    const r = canvas.getBoundingClientRect();
+    return { x: e.clientX - r.left, y: e.clientY - r.top };
+  }
+
+  canvas.addEventListener('pointerdown', (e) => {
+    const p = pointerPos(e);
+    // Tap-to-select if hitting a contact
+    const hit = window.RadarView.hitTestContact(p.x, p.y);
+    if (hit) {
+      sim.setActive(hit.id);
+      e.preventDefault();
+      return;
+    }
+    // Start a long-press timer
+    press = {
+      startX: p.x, startY: p.y, t0: performance.now(),
+      started: false, drop: null, pointerId: e.pointerId,
+    };
+    press.timer = setTimeout(() => {
+      if (!press) return;
+      press.started = true;
+      const { bearing, range } = window.RadarView.canvasToPolar(press.startX, press.startY);
+      press.drop = { bearing, range };
+      window.RadarView.setGhost({ bearing, range, course: null, speed: 10 });
+      canvas.setPointerCapture(press.pointerId);
+    }, LONG_PRESS_MS);
+  });
+
+  canvas.addEventListener('pointermove', (e) => {
+    if (!press) return;
+    const p = pointerPos(e);
+
+    if (!press.started) {
+      // Cancel long-press if user moves too far before timer fires
+      if (Math.hypot(p.x - press.startX, p.y - press.startY) > MOVE_CANCEL_PX) {
+        clearTimeout(press.timer);
+        press = null;
+      }
+      return;
+    }
+
+    // Post-drop: dragging sets course
+    const { bearing: dropBrg, range: dropRng } = press.drop;
+    const cx = canvas.width / (window.devicePixelRatio || 1) / 2;
+    const cy = canvas.height / (window.devicePixelRatio || 1) / 2;
+    const nmToPx = (canvas.clientWidth / 2 - 18) / window.RadarView.getRange();
+    const dropX = cx + Math.sin(dropBrg * Math.PI / 180) * dropRng * nmToPx;
+    const dropY = cy - Math.cos(dropBrg * Math.PI / 180) * dropRng * nmToPx;
+    const dx = p.x - dropX;
+    const dy = dropY - p.y;   // canvas y flipped
+    const course = Math.hypot(dx, dy) < 6 ? null
+                  : ((Math.atan2(dx, dy) * 180 / Math.PI) + 360) % 360;
+    window.RadarView.setGhost({ bearing: dropBrg, range: dropRng, course, speed: 10 });
+  });
+
+  canvas.addEventListener('pointerup', (e) => {
+    if (!press) return;
+    clearTimeout(press.timer);
+    if (press.started) {
+      try { canvas.releasePointerCapture(press.pointerId); } catch (_) {}
+      const { bearing, range } = press.drop;
+      const p = pointerPos(e);
+      const cx = canvas.width / (window.devicePixelRatio || 1) / 2;
+      const cy = canvas.height / (window.devicePixelRatio || 1) / 2;
+      const nmToPx = (canvas.clientWidth / 2 - 18) / window.RadarView.getRange();
+      const dropX = cx + Math.sin(bearing * Math.PI / 180) * range * nmToPx;
+      const dropY = cy - Math.cos(bearing * Math.PI / 180) * range * nmToPx;
+      const dx = p.x - dropX;
+      const dy = dropY - p.y;
+      let course;
+      if (Math.hypot(dx, dy) < 6) {
+        course = bearing; // point toward ownship region if no drag
+      } else {
+        course = ((Math.atan2(dx, dy) * 180 / Math.PI) + 360) % 360;
+      }
+      const c = sim.addContact({ bearing, range, course, speed: 10 });
+      sim.setActive(c.id);
+    }
+    window.RadarView.setGhost(null);
+    press = null;
+  });
+
+  canvas.addEventListener('pointercancel', () => {
+    if (press) { clearTimeout(press.timer); }
+    window.RadarView.setGhost(null);
+    press = null;
+  });
+
+  // --- Inline editors -----------------------------------------
+  const EDITORS = {
+    'own-crs':   { label: 'Own Course', get: () => fmtCrs(sim.own.course), set: (v) => sim.setOwnCourse(v), step: 5 },
+    'own-spd':   { label: 'Own Speed',  get: () => fmtSpd(sim.own.speed),  set: (v) => sim.setOwnSpeed(v),  step: 1 },
+    'track-crs': { label: 'Track Course', get: () => { const c = sim.getActive(); return c ? fmtCrs(c.course) : '—'; },
+                   set: (v) => { const c = sim.getActive(); if (c) sim.setTrackCourse(c.id, v); }, step: 5 },
+    'track-spd': { label: 'Track Speed',  get: () => { const c = sim.getActive(); return c ? fmtSpd(c.speed) : '—'; },
+                   set: (v) => { const c = sim.getActive(); if (c) sim.setTrackSpeed(c.id, v); }, step: 1 },
+  };
+
+  let currentEditor = null;
+  function openEditor(target) {
+    const key = target.dataset.edit;
+    const cfg = EDITORS[key];
+    if (!cfg) return;
+    const v = cfg.get();
+    if (v === '—') return;
+    currentEditor = { key, cfg, target };
+    el.editLabel.textContent = cfg.label;
+    el.editInput.value = parseFloat(v);
+    el.editInput.step = cfg.step;
+    const r = target.getBoundingClientRect();
+    el.editPop.hidden = false;
+    el.editPop.style.left = Math.max(8, r.left - 20) + 'px';
+    el.editPop.style.top = (r.bottom + 6) + 'px';
+    target.classList.add('is-editing');
+    setTimeout(() => { el.editInput.focus(); el.editInput.select(); }, 0);
+  }
+  function closeEditor(commit) {
+    if (!currentEditor) return;
+    if (commit) {
+      const v = parseFloat(el.editInput.value);
+      if (!Number.isNaN(v)) currentEditor.cfg.set(v);
+    }
+    currentEditor.target.classList.remove('is-editing');
+    el.editPop.hidden = true;
+    currentEditor = null;
+  }
+
+  document.addEventListener('click', (e) => {
+    const target = e.target.closest('.editable');
+    if (target && !target.classList.contains('is-editing')) {
+      // Close any open editor first
+      closeEditor(false);
+      openEditor(target);
+      e.stopPropagation();
+      return;
+    }
+    if (!el.editPop.contains(e.target)) closeEditor(false);
+  });
+
+  el.editInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { closeEditor(true); e.preventDefault(); }
+    if (e.key === 'Escape') { closeEditor(false); e.preventDefault(); }
+  });
+
+  // Initial render
+  renderPanel();
+  sim.play();
+  el.play.classList.add('is-playing');
+})();

--- a/prototypes/redesign/index.html
+++ b/prototypes/redesign/index.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Maneuver — Sandbox</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&family=Inter:wght@500;600;700&display=swap" />
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body class="app">
+
+  <!-- LEFT RAIL -->
+  <aside class="rail" aria-label="Primary">
+    <a class="rail__logo" href="#" aria-label="Maneuver">
+      <img src="../../public/group-27.svg" alt="" />
+      <img src="../../public/group-28.svg" alt="" />
+    </a>
+    <div class="rail__spacer"></div>
+    <button class="rail__btn" id="clear-btn" aria-label="Clear all contacts" title="Clear contacts">
+      <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M5 5l10 10M15 5L5 15" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/></svg>
+    </button>
+  </aside>
+
+  <!-- STAGE (radar) -->
+  <main class="stage">
+    <div class="radar">
+      <canvas id="radar-canvas" aria-label="Radar display"></canvas>
+
+      <button class="radar__range" id="range-pill" aria-label="Cycle range">
+        <span class="range__val" id="range-val">12</span>
+        <span class="range__unit">NM</span>
+      </button>
+    </div>
+  </main>
+
+  <!-- TRANSPORT — sibling of stage so we can place it below the panel on mobile -->
+  <footer class="transport">
+    <button class="transport__play" id="play-btn" aria-label="Play or pause">
+      <svg class="icon-play" viewBox="0 0 14 14"><path d="M3.5 2 L12 7 L3.5 12 Z" fill="currentColor"/></svg>
+      <svg class="icon-pause" viewBox="0 0 14 14"><rect x="3.25" y="2.25" width="3" height="9.5" rx="0.75" fill="currentColor"/><rect x="7.75" y="2.25" width="3" height="9.5" rx="0.75" fill="currentColor"/></svg>
+    </button>
+
+    <div class="transport__clock" id="sim-clock">00:00:00</div>
+
+    <div class="transport__scrub" id="scrub" role="slider" aria-label="Scrub time" tabindex="0">
+      <div class="scrub__track"></div>
+      <div class="scrub__fill" id="scrub-fill" style="--pct:0%"></div>
+      <div class="scrub__head" id="scrub-head" style="--pct:0%"></div>
+    </div>
+
+    <div class="transport__speeds" role="radiogroup" aria-label="Simulation speed">
+      <button class="speed" role="radio" data-speed="1">1×</button>
+      <button class="speed is-active" role="radio" data-speed="2" aria-checked="true">2×</button>
+      <button class="speed" role="radio" data-speed="4">4×</button>
+      <button class="speed" role="radio" data-speed="8">8×</button>
+    </div>
+  </footer>
+
+  <!-- RIGHT TELEMETRY -->
+  <aside class="panel" aria-label="Telemetry">
+
+    <!-- TRACK SECTION -->
+    <section class="track" id="track-hero" aria-live="polite">
+      <header class="track__head">
+        <span class="track__tag" id="track-tag">—</span>
+        <span class="track__state" id="track-state"></span>
+      </header>
+
+      <!-- CBDR / bearing drift -->
+      <div class="cbdr" id="cbdr-strip" data-state="idle">
+        <span class="cbdr__state" id="cbdr-state">—</span>
+        <svg class="cbdr__spark" id="cbdr-spark" viewBox="0 0 120 20" preserveAspectRatio="none" aria-hidden="true">
+          <polyline id="cbdr-spark-path" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" points=""/>
+        </svg>
+        <span class="cbdr__delta" id="cbdr-delta">—<span class="u">/m</span></span>
+      </div>
+
+      <!-- Hero numbers -->
+      <div class="hero">
+        <div class="hero__cell hero__cell--primary">
+          <span class="hero__lbl">CPA</span>
+          <span class="hero__val"><span id="cpa-rng-val">—</span><span class="hero__unit">NM</span></span>
+        </div>
+        <div class="hero__cell">
+          <span class="hero__lbl">TCPA</span>
+          <span class="hero__val" id="cpa-time">—</span>
+        </div>
+        <div class="hero__aspect">
+          <svg class="aspect" viewBox="-50 -50 100 100" aria-hidden="true">
+            <circle cx="0" cy="0" r="42" fill="none" stroke="#2A2E38" stroke-width="1"/>
+            <line x1="0" y1="-42" x2="0" y2="-36" stroke="#8A8E97" stroke-width="1"/>
+            <line x1="0" y1="42" x2="0" y2="36" stroke="#8A8E97" stroke-width="1"/>
+            <line x1="-42" y1="0" x2="-36" y2="0" stroke="#8A8E97" stroke-width="1"/>
+            <line x1="42" y1="0" x2="36" y2="0" stroke="#8A8E97" stroke-width="1"/>
+            <path id="aspect-wedge" d="" fill="#FF6B2C" fill-opacity="0.28" stroke="#FF6B2C" stroke-width="1.25"/>
+            <circle cx="0" cy="0" r="2.5" fill="#F2F0EA"/>
+          </svg>
+          <div class="hero__aspect-txt">
+            <span class="hero__lbl">Aspect</span>
+            <span class="hero__val-sm" id="aspect-val">—</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Data grid -->
+      <div class="grid">
+        <div class="cell"><span class="cell__lbl">Brg</span><span class="cell__val" id="d-brg">—</span></div>
+        <div class="cell"><span class="cell__lbl">Rng</span><span class="cell__val" id="d-rng">—</span></div>
+        <div class="cell editable" data-edit="track-crs"><span class="cell__lbl">Crs</span><span class="cell__val" id="d-crs">—</span></div>
+        <div class="cell editable" data-edit="track-spd"><span class="cell__lbl">Spd</span><span class="cell__val" id="d-spd">—</span></div>
+        <div class="cell"><span class="cell__lbl">Rel Dir</span><span class="cell__val" id="d-rdir">—</span></div>
+        <div class="cell"><span class="cell__lbl">Rel Spd</span><span class="cell__val" id="d-rspd">—</span></div>
+        <div class="cell"><span class="cell__lbl">Brg Rate</span><span class="cell__val" id="d-brate">—</span></div>
+        <div class="cell"><span class="cell__lbl">Tgt Ang</span><span class="cell__val" id="d-tang">—</span></div>
+      </div>
+    </section>
+
+    <!-- CONTACTS -->
+    <section class="contacts">
+      <header class="contacts__head">
+        <h3 class="contacts__title">Contacts <span class="contacts__count" id="contact-count">0</span></h3>
+        <span class="contacts__hint">long-press the radar to drop</span>
+      </header>
+      <ul class="contacts__list" id="contact-list"></ul>
+      <div class="contacts__empty" id="contacts-empty">
+        <span>No contacts yet.</span>
+        <span class="contacts__empty-hint">Long-press anywhere on the radar, then drag to set course.</span>
+      </div>
+    </section>
+
+    <!-- OWNSHIP -->
+    <section class="own">
+      <div class="own__row">
+        <span class="own__lbl">Ownship</span>
+        <span class="own__val">
+          <span class="editable" data-edit="own-crs"><span id="own-crs">000</span>°<span class="own__u">T</span></span>
+          <span class="sep">·</span>
+          <span class="editable" data-edit="own-spd"><span id="own-spd">12</span><span class="own__u">kt</span></span>
+        </span>
+      </div>
+    </section>
+  </aside>
+
+  <!-- MOBILE TOPBAR -->
+  <header class="topbar" aria-hidden="true">
+    <a class="topbar__logo" href="#" aria-label="Maneuver">
+      <img src="../../public/group-27.svg" alt="" />
+      <img src="../../public/group-28.svg" alt="" />
+    </a>
+    <button class="topbar__btn" id="clear-btn-mobile" aria-label="Clear contacts">
+      <svg viewBox="0 0 20 20"><path d="M5 5l10 10M15 5L5 15" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/></svg>
+    </button>
+  </header>
+
+  <!-- Inline edit popover -->
+  <div class="edit-pop" id="edit-pop" hidden>
+    <label class="edit-pop__lbl" id="edit-pop-label">Course</label>
+    <input class="edit-pop__input" id="edit-pop-input" type="number" inputmode="decimal" />
+    <div class="edit-pop__hint">↵ apply · Esc cancel</div>
+  </div>
+
+  <script src="./sim.js" defer></script>
+  <script src="./radar.js" defer></script>
+  <script src="./app.js" defer></script>
+</body>
+</html>

--- a/prototypes/redesign/radar.js
+++ b/prototypes/redesign/radar.js
@@ -1,0 +1,341 @@
+/* =========================================================
+   Radar renderer
+   Reads from Maneuver.Sim state; draws polar grid, ownship,
+   contacts, CPA indicators, and a "ghost" contact while the
+   user is dropping one via long-press + drag.
+   ========================================================= */
+
+(function () {
+  const canvas = document.getElementById('radar-canvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const dpr = () => window.devicePixelRatio || 1;
+
+  const state = {
+    rangeNm: 12,
+    sim: null,
+    ghost: null,   // { bearing, range, course, speed } while dropping
+    dim: 0,
+    cx: 0, cy: 0, R: 0,
+  };
+
+  // --- Geometry helpers ---------------------------------------
+  function bearingToXY(cx, cy, rPx, brg) {
+    const a = (brg - 90) * Math.PI / 180;   // canvas: 0° = east, we want 0 = N
+    return { x: cx + rPx * Math.cos(a), y: cy + rPx * Math.sin(a) };
+  }
+  // World (dx, dy) relative to ownship → canvas coords. +y world = north = canvas up.
+  function worldToCanvas(dx, dy) {
+    const nmToPx = state.R / state.rangeNm;
+    return { x: state.cx + dx * nmToPx, y: state.cy - dy * nmToPx };
+  }
+  // Canvas coords → world bearing and range relative to ownship
+  function canvasToPolar(px, py) {
+    const dx = (px - state.cx);
+    const dy = (state.cy - py);
+    const nmToPx = state.R / state.rangeNm;
+    const xNm = dx / nmToPx;
+    const yNm = dy / nmToPx;
+    const brg = ((Math.atan2(xNm, yNm) * 180) / Math.PI + 360) % 360;
+    const rng = Math.hypot(xNm, yNm);
+    return { bearing: brg, range: rng, xNm, yNm };
+  }
+
+  // --- Canvas fitting -----------------------------------------
+  function fitDPR() {
+    const parent = canvas.parentElement;
+    const rect = parent.getBoundingClientRect();
+    const dim = Math.max(200, Math.floor(Math.min(rect.width, rect.height)));
+    canvas.width = Math.round(dim * dpr());
+    canvas.height = Math.round(dim * dpr());
+    canvas.style.width = dim + 'px';
+    canvas.style.height = dim + 'px';
+    ctx.setTransform(dpr(), 0, 0, dpr(), 0, 0);
+    state.dim = dim;
+    state.cx = dim / 2;
+    state.cy = dim / 2;
+    state.R = dim / 2 - 18;
+    return dim;
+  }
+
+  // --- Drawing primitives -------------------------------------
+  function drawGrid() {
+    const { cx, cy, R } = state;
+    const RINGS = 4;
+
+    // Faint sweep
+    const grad = ctx.createRadialGradient(cx, cy, R * 0.1, cx, cy, R);
+    grad.addColorStop(0, 'rgba(117,251,76,0.04)');
+    grad.addColorStop(1, 'rgba(117,251,76,0.00)');
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.arc(cx, cy, R, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Range rings
+    ctx.lineWidth = 1;
+    for (let i = 1; i <= RINGS; i++) {
+      const r = (R / RINGS) * i;
+      ctx.strokeStyle = i === RINGS ? 'rgba(117,251,76,0.3)' : 'rgba(74,156,46,0.25)';
+      ctx.beginPath();
+      ctx.arc(cx, cy, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    // Bearing spokes every 30°
+    ctx.strokeStyle = 'rgba(42,46,56,0.85)';
+    for (let b = 0; b < 360; b += 30) {
+      const a = (b - 90) * Math.PI / 180;
+      ctx.beginPath();
+      ctx.moveTo(cx, cy);
+      ctx.lineTo(cx + R * Math.cos(a), cy + R * Math.sin(a));
+      ctx.stroke();
+    }
+
+    // Cardinal labels
+    ctx.font = '11px "IBM Plex Mono", monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    for (const [t, b] of [['N', 0], ['E', 90], ['S', 180], ['W', 270]]) {
+      const p = bearingToXY(cx, cy, R + 10, b);
+      ctx.fillStyle = b === 0 ? '#F2F0EA' : '#8A8E97';
+      ctx.fillText(t, p.x, p.y);
+    }
+
+    // Range labels on 045 arc
+    ctx.fillStyle = '#61656E';
+    ctx.textAlign = 'left';
+    for (let i = 1; i <= RINGS; i++) {
+      const r = (R / RINGS) * i;
+      const v = (state.rangeNm / RINGS) * i;
+      const p = bearingToXY(cx, cy, r, 45);
+      ctx.fillText(v.toFixed(v < 10 ? 1 : 0), p.x + 4, p.y - 4);
+    }
+  }
+
+  function drawOwnship() {
+    const { cx, cy, R } = state;
+    const sim = state.sim;
+    if (!sim) return;
+
+    const vecLen = Math.min(R * 0.25, (sim.own.speed / 35) * R * 0.45);
+    const tip = bearingToXY(cx, cy, vecLen, sim.own.course);
+
+    ctx.strokeStyle = '#75FB4C';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(tip.x, tip.y);
+    ctx.stroke();
+
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.rotate((sim.own.course) * Math.PI / 180);
+    ctx.fillStyle = '#F2F0EA';
+    ctx.beginPath();
+    ctx.moveTo(0, -8);
+    ctx.lineTo(6, 6);
+    ctx.lineTo(0, 3);
+    ctx.lineTo(-6, 6);
+    ctx.closePath();
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(242,240,234,0.35)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(0, 0, 12, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  function drawContact(c) {
+    const sim = state.sim;
+    const d = c.derived;
+    if (!d) return;
+
+    // Cull contacts beyond 1.2× range (still drawn faded)
+    const outside = d.range > state.rangeNm;
+
+    const dx = c.x - sim.own.x;
+    const dy = c.y - sim.own.y;
+    const p = worldToCanvas(dx, dy);
+
+    // Trail (world-space history dots)
+    for (let i = 0; i < c.trail.length; i++) {
+      const t = c.trail[i];
+      const tp = worldToCanvas(t.x - sim.own.x, t.y - sim.own.y);
+      const age = c.trail.length - i;
+      ctx.fillStyle = `rgba(138,142,151,${0.25 - age * 0.02})`;
+      ctx.beginPath();
+      ctx.arc(tp.x, tp.y, 1.4, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    // Course vector (6-minute projection)
+    const vecNm = (c.speed / 60) * 6;
+    const tipWorld = {
+      x: (c.x - sim.own.x) + Math.sin(c.course * Math.PI / 180) * vecNm,
+      y: (c.y - sim.own.y) + Math.cos(c.course * Math.PI / 180) * vecNm,
+    };
+    const tipCanvas = worldToCanvas(tipWorld.x, tipWorld.y);
+
+    ctx.strokeStyle = d.isRisk ? '#FF6B2C' : 'rgba(242,240,234,0.55)';
+    ctx.lineWidth = 1.4;
+    ctx.setLineDash([]);
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y);
+    ctx.lineTo(tipCanvas.x, tipCanvas.y);
+    ctx.stroke();
+
+    // Arrowhead
+    ctx.save();
+    ctx.translate(tipCanvas.x, tipCanvas.y);
+    ctx.rotate((c.course) * Math.PI / 180);
+    ctx.fillStyle = d.isRisk ? '#FF6B2C' : 'rgba(242,240,234,0.7)';
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(4, 6);
+    ctx.lineTo(-4, 6);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+
+    // CPA dashed line + X marker (risk or active only)
+    const isActive = c.id === sim.activeId;
+    if ((d.isRisk || isActive) && !d.hasPassed) {
+      const tcpaH = d.tcpaSec / 3600;
+      const relVx = c.vx - sim.own.vx;
+      const relVy = c.vy - sim.own.vy;
+      const cpaWorldX = (c.x - sim.own.x) + relVx * tcpaH;
+      const cpaWorldY = (c.y - sim.own.y) + relVy * tcpaH;
+      const cpaCanvas = worldToCanvas(cpaWorldX, cpaWorldY);
+
+      ctx.setLineDash([3, 3]);
+      ctx.strokeStyle = d.isRisk ? 'rgba(255,107,44,0.65)' : 'rgba(242,240,234,0.35)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(p.x, p.y);
+      ctx.lineTo(cpaCanvas.x, cpaCanvas.y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+
+      ctx.strokeStyle = d.isRisk ? '#FF6B2C' : '#F2F0EA';
+      ctx.lineWidth = 1.2;
+      ctx.beginPath();
+      ctx.moveTo(cpaCanvas.x - 4, cpaCanvas.y - 4);
+      ctx.lineTo(cpaCanvas.x + 4, cpaCanvas.y + 4);
+      ctx.moveTo(cpaCanvas.x + 4, cpaCanvas.y - 4);
+      ctx.lineTo(cpaCanvas.x - 4, cpaCanvas.y + 4);
+      ctx.stroke();
+    }
+
+    // Selection ring
+    if (isActive) {
+      ctx.strokeStyle = d.isRisk ? '#FF6B2C' : '#F2F0EA';
+      ctx.lineWidth = 1.5;
+      ctx.setLineDash([2, 3]);
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 14, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+
+    // Contact dot
+    ctx.globalAlpha = outside ? 0.45 : 1;
+    ctx.fillStyle = d.isRisk ? '#FF6B2C' : '#F2F0EA';
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, d.isRisk ? 5 : 4, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+
+    // Label
+    ctx.fillStyle = isActive ? '#F2F0EA' : '#C9C7C1';
+    ctx.font = '500 11px "IBM Plex Mono", monospace';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    const dxLbl = p.x - state.cx;
+    const dyLbl = p.y - state.cy;
+    const mag = Math.hypot(dxLbl, dyLbl) || 1;
+    const lx = p.x + (dxLbl / mag) * 12;
+    const ly = p.y + (dyLbl / mag) * 12;
+    ctx.fillText(c.id, lx, ly);
+  }
+
+  function drawGhost() {
+    if (!state.ghost) return;
+    const g = state.ghost;
+    const { cx, cy, R } = state;
+    const nmToPx = R / state.rangeNm;
+
+    const bx = cx + Math.sin(g.bearing * Math.PI / 180) * (g.range * nmToPx);
+    const by = cy - Math.cos(g.bearing * Math.PI / 180) * (g.range * nmToPx);
+
+    ctx.save();
+    ctx.globalAlpha = 0.8;
+    ctx.fillStyle = '#F2F0EA';
+    ctx.beginPath();
+    ctx.arc(bx, by, 4, 0, Math.PI * 2);
+    ctx.fill();
+    if (g.course !== null) {
+      const vecNm = (g.speed || 10) / 60 * 6;
+      const vx = Math.sin(g.course * Math.PI / 180) * vecNm * nmToPx;
+      const vy = -Math.cos(g.course * Math.PI / 180) * vecNm * nmToPx;
+      ctx.strokeStyle = '#F2F0EA';
+      ctx.lineWidth = 1.4;
+      ctx.setLineDash([3, 3]);
+      ctx.beginPath();
+      ctx.moveTo(bx, by);
+      ctx.lineTo(bx + vx, by + vy);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+    ctx.restore();
+  }
+
+  // --- Hit-test (for tap-to-select) ---------------------------
+  function hitTestContact(px, py) {
+    const sim = state.sim;
+    if (!sim) return null;
+    for (const c of sim.contacts) {
+      const dx = c.x - sim.own.x;
+      const dy = c.y - sim.own.y;
+      const p = worldToCanvas(dx, dy);
+      if (Math.hypot(p.x - px, p.y - py) <= 14) return c;
+    }
+    return null;
+  }
+
+  // --- Main draw ----------------------------------------------
+  function draw() {
+    fitDPR();
+    ctx.clearRect(0, 0, state.dim, state.dim);
+    drawGrid();
+    const sim = state.sim;
+    if (sim) {
+      // Non-risk first so risk renders on top
+      const ordered = [...sim.contacts].sort(
+        (a, b) => Number(!!(a.derived?.isRisk)) - Number(!!(b.derived?.isRisk))
+      );
+      for (const c of ordered) drawContact(c);
+    }
+    drawOwnship();
+    drawGhost();
+  }
+
+  // --- Public API ---------------------------------------------
+  window.RadarView = {
+    attach(sim) { state.sim = sim; sim.on(() => requestAnimationFrame(draw)); draw(); },
+    setRange(nm) { state.rangeNm = nm; draw(); },
+    getRange() { return state.rangeNm; },
+    setGhost(g) { state.ghost = g; draw(); },
+    canvasToPolar,
+    hitTestContact,
+    redraw: draw,
+    canvas,
+  };
+
+  // Redraw on resize
+  window.addEventListener('resize', () => requestAnimationFrame(draw));
+  if ('ResizeObserver' in window && canvas.parentElement) {
+    new ResizeObserver(() => requestAnimationFrame(draw)).observe(canvas.parentElement);
+  }
+})();

--- a/prototypes/redesign/sim.js
+++ b/prototypes/redesign/sim.js
@@ -1,0 +1,277 @@
+/* =========================================================
+   Maneuver sandbox simulation engine
+   --------------------------------------------------------
+   Units:
+     position  NM  (+y = north, +x = east)
+     speed     kt  (NM/hour)
+     bearing   deg (0 = north, clockwise)
+     time      s   (seconds, internal)
+   Ownship is tracked in world coordinates and rendered at
+   the center of the radar display.
+   --------------------------------------------------------
+   Math ported from js/arena.js (solveCPA, calculateAllData,
+   getBearingRate).
+   ========================================================= */
+
+(function (global) {
+  const DEG = 180 / Math.PI;
+  const RAD = Math.PI / 180;
+
+  const norm360 = (deg) => ((deg % 360) + 360) % 360;
+  const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+
+  function velFromCourseSpeed(courseDeg, speedKt) {
+    const r = courseDeg * RAD;
+    return { vx: Math.sin(r) * speedKt, vy: Math.cos(r) * speedKt };
+  }
+
+  function solveCPA(own, tgt) {
+    const rx = tgt.x - own.x;
+    const ry = tgt.y - own.y;
+    const vx = tgt.vx - own.vx;
+    const vy = tgt.vy - own.vy;
+    const v2 = vx * vx + vy * vy;
+    const tCPA = v2 < 1e-6 ? Infinity : -(rx * vx + ry * vy) / v2;
+    const xC = rx + vx * tCPA;
+    const yC = ry + vy * tCPA;
+    const dCPA = Math.sqrt(xC * xC + yC * yC);
+    return { tCPA, dCPA, xCPA: xC, yCPA: yC };
+  }
+
+  function bearingOf(dx, dy) { return norm360(Math.atan2(dx, dy) * DEG); }
+  function rangeOf(dx, dy)   { return Math.hypot(dx, dy); }
+
+  class Sim {
+    constructor() {
+      // Ownship at origin, heading North, 12 kt by default
+      this.own = { x: 0, y: 0, course: 0, speed: 12, vx: 0, vy: 12 };
+      this.contacts = [];
+      this.nextId = 1;
+      this.time = 0;             // seconds since start
+      this.speed = 2;            // time multiplier
+      this.playing = false;
+      this.activeId = null;
+      this.listeners = new Set();
+    }
+
+    // Subscription ---------------------------------------------
+    on(fn) { this.listeners.add(fn); return () => this.listeners.delete(fn); }
+    _emit() { for (const fn of this.listeners) fn(this); }
+
+    // Ownship editing ------------------------------------------
+    setOwnCourse(deg) {
+      this.own.course = norm360(deg);
+      const v = velFromCourseSpeed(this.own.course, this.own.speed);
+      this.own.vx = v.vx; this.own.vy = v.vy;
+      this._recomputeAll();
+      this._emit();
+    }
+    setOwnSpeed(kt) {
+      this.own.speed = clamp(kt, 0, 35);
+      const v = velFromCourseSpeed(this.own.course, this.own.speed);
+      this.own.vx = v.vx; this.own.vy = v.vy;
+      this._recomputeAll();
+      this._emit();
+    }
+
+    // Contact management ---------------------------------------
+    addContact({ bearing, range, course, speed }) {
+      const br = bearing * RAD;
+      const x = this.own.x + Math.sin(br) * range;
+      const y = this.own.y + Math.cos(br) * range;
+      const v = velFromCourseSpeed(course, speed);
+      const id = `T-${String(this.nextId++).padStart(2, '0')}`;
+      const c = {
+        id,
+        x, y,
+        course: norm360(course),
+        speed: clamp(speed, 0, 35),
+        vx: v.vx, vy: v.vy,
+        bearingHistory: [],       // [{t, brg}] recent samples
+        trail: [],                // world-space dots for rendering
+        derived: null,
+      };
+      this.contacts.push(c);
+      this._recomputeContact(c);
+      if (!this.activeId) this.activeId = id;
+      this._emit();
+      return c;
+    }
+    removeContact(id) {
+      this.contacts = this.contacts.filter((c) => c.id !== id);
+      if (this.activeId === id) this.activeId = this.contacts[0]?.id ?? null;
+      this._emit();
+    }
+    clearContacts() {
+      this.contacts = [];
+      this.activeId = null;
+      this.nextId = 1;
+      this._emit();
+    }
+    setActive(id) {
+      if (this.contacts.some((c) => c.id === id)) {
+        this.activeId = id;
+        this._emit();
+      }
+    }
+    getActive() { return this.contacts.find((c) => c.id === this.activeId) || null; }
+
+    // Edit selected track --------------------------------------
+    setTrackCourse(id, deg) {
+      const c = this.contacts.find((x) => x.id === id);
+      if (!c) return;
+      c.course = norm360(deg);
+      const v = velFromCourseSpeed(c.course, c.speed);
+      c.vx = v.vx; c.vy = v.vy;
+      this._recomputeContact(c);
+      this._emit();
+    }
+    setTrackSpeed(id, kt) {
+      const c = this.contacts.find((x) => x.id === id);
+      if (!c) return;
+      c.speed = clamp(kt, 0, 35);
+      const v = velFromCourseSpeed(c.course, c.speed);
+      c.vx = v.vx; c.vy = v.vy;
+      this._recomputeContact(c);
+      this._emit();
+    }
+
+    // Time control ---------------------------------------------
+    play()  { this.playing = true;  this._emit(); }
+    pause() { this.playing = false; this._emit(); }
+    toggle(){ this.playing = !this.playing; this._emit(); }
+    setSpeed(mult) { this.speed = mult; this._emit(); }
+
+    // Per-frame tick (called by driver loop) -------------------
+    tick(dtSec) {
+      if (!this.playing) return;
+      const dt = dtSec * this.speed;
+      const dtH = dt / 3600;
+
+      // integrate ownship
+      this.own.x += this.own.vx * dtH;
+      this.own.y += this.own.vy * dtH;
+
+      // integrate contacts
+      for (const c of this.contacts) {
+        c.x += c.vx * dtH;
+        c.y += c.vy * dtH;
+      }
+
+      this.time += dt;
+      this._recomputeAll();
+      this._sampleBearings();
+      this._emit();
+    }
+
+    // --- Derived data -----------------------------------------
+    _recomputeAll() {
+      for (const c of this.contacts) this._recomputeContact(c);
+    }
+
+    _recomputeContact(c) {
+      const dx = c.x - this.own.x;
+      const dy = c.y - this.own.y;
+      const range = rangeOf(dx, dy);
+      const brg = bearingOf(dx, dy);
+
+      const relVx = c.vx - this.own.vx;
+      const relVy = c.vy - this.own.vy;
+      const relSpd = Math.hypot(relVx, relVy);
+      const relDir = relSpd < 1e-4 ? null : norm360(Math.atan2(relVx, relVy) * DEG);
+
+      const cpa = solveCPA(this.own, c);
+      const tcpaSec = cpa.tCPA * 3600;   // hours → seconds
+      const hasPassed = tcpaSec < 0 || !isFinite(tcpaSec);
+
+      // Target angle (aspect): angle from target's bow to ownship
+      const ownFromTgt = norm360(brg + 180);
+      const tgtAngle = norm360(ownFromTgt - c.course);
+
+      // Bearing rate via cross product (deg/min)
+      const cross = dx * relVy - dy * relVx;          // rel pos × rel vel
+      const brateRadPerHour = range < 0.01 ? 0 : cross / (range * range);
+      const brateDpm = (brateRadPerHour * DEG) / 60;
+
+      // CBDR classification: risk iff dCPA < 1.0 NM AND 0 < tcpa < 15 min
+      const isRisk = !hasPassed && cpa.dCPA < 1.0 && tcpaSec < 15 * 60;
+      const isSteady = Math.abs(brateDpm) < 0.2 && !hasPassed;
+
+      c.derived = {
+        range, bearing: brg,
+        relDir, relSpd,
+        cpaRange: cpa.dCPA,
+        tcpaSec,
+        hasPassed,
+        targetAngle: tgtAngle,
+        bearingRateDpm: brateDpm,
+        bearingRateWord: Math.abs(brateDpm) < 0.05 ? 'STEADY'
+                          : brateDpm > 0 ? 'L' : 'R',
+        isRisk,
+        isSteady,
+      };
+    }
+
+    _sampleBearings() {
+      // Sample every 1s, keep last 60 samples
+      for (const c of this.contacts) {
+        const last = c.bearingHistory[c.bearingHistory.length - 1];
+        if (!last || this.time - last.t >= 1) {
+          c.bearingHistory.push({ t: this.time, brg: c.derived.bearing });
+          if (c.bearingHistory.length > 60) c.bearingHistory.shift();
+        }
+        // Trail (world-space), sample every 6 seconds, keep 10
+        const lastTrail = c.trail[c.trail.length - 1];
+        if (!lastTrail || this.time - lastTrail.t >= 6) {
+          c.trail.push({ t: this.time, x: c.x, y: c.y });
+          if (c.trail.length > 10) c.trail.shift();
+        }
+      }
+    }
+
+    // Bearing drift over the window (last N samples) -----------
+    bearingDrift(c, windowSec = 60) {
+      const h = c.bearingHistory;
+      if (h.length < 2) return { drift: 0, series: [] };
+      const cutoff = this.time - windowSec;
+      const recent = h.filter((s) => s.t >= cutoff);
+      if (recent.length < 2) return { drift: 0, series: h };
+
+      // Unwrap bearing around 0/360 to avoid jumps when plotting
+      const unwrap = [recent[0].brg];
+      for (let i = 1; i < recent.length; i++) {
+        let next = recent[i].brg;
+        const prev = unwrap[i - 1];
+        while (next - prev > 180) next -= 360;
+        while (next - prev < -180) next += 360;
+        unwrap.push(next);
+      }
+      const drift = unwrap[unwrap.length - 1] - unwrap[0];
+      return {
+        drift,
+        series: recent.map((s, i) => ({ t: s.t, brg: unwrap[i] })),
+      };
+    }
+  }
+
+  // Aspect word ("Red 42°", "Green 30°", "Bow", "Stern")
+  function aspectLabel(targetAngle) {
+    // targetAngle convention: 0 = ownship is dead ahead of target (target's bow)
+    // 90 = ownship on target's stbd beam, 180 = stern, 270 = port beam.
+    const ta = norm360(targetAngle);
+    if (ta < 5 || ta > 355) return 'Bow';
+    if (Math.abs(ta - 180) < 5) return 'Stern';
+    if (ta < 180) return `Green ${Math.round(ta)}°`;
+    return `Red ${Math.round(360 - ta)}°`;
+  }
+
+  global.Maneuver = {
+    Sim,
+    solveCPA,
+    bearingOf,
+    rangeOf,
+    velFromCourseSpeed,
+    aspectLabel,
+    norm360,
+  };
+})(window);

--- a/prototypes/redesign/styles.css
+++ b/prototypes/redesign/styles.css
@@ -1,0 +1,714 @@
+/* =========================================================
+   Maneuver · "Instrument" redesign prototype
+   ========================================================= */
+
+:root {
+  /* Palette */
+  --ink: #0B0C0E;
+  --ink-2: #101218;
+  --steel: #151821;
+  --hull: #2A2E38;
+  --hull-soft: rgba(42, 46, 56, 0.6);
+  --fog: #8A8E97;
+  --fog-soft: #61656E;
+  --bone: #F2F0EA;
+  --bone-dim: #C9C7C1;
+  --flare: #FF6B2C;
+  --flare-soft: rgba(255, 107, 44, 0.22);
+  --flare-edge: rgba(255, 107, 44, 0.5);
+  --radar-green: #75FB4C;
+  --radar-green-dim: #4A9C2E;
+  --radar-green-faint: rgba(117, 251, 76, 0.28);
+
+  /* Type */
+  --font-sans: 'IBM Plex Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, 'SF Mono', monospace;
+  --font-display: 'Inter', 'IBM Plex Sans', sans-serif;
+
+  /* Scale */
+  --fs-11: 11px;
+  --fs-13: 13px;
+  --fs-16: 16px;
+  --fs-20: 20px;
+  --fs-28: 28px;
+  --fs-44: 44px;
+
+  /* Spacing */
+  --s-4: 4px;
+  --s-8: 8px;
+  --s-12: 12px;
+  --s-16: 16px;
+  --s-24: 24px;
+  --s-40: 40px;
+  --s-72: 72px;
+
+  /* Motion */
+  --ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --dur: 160ms;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  height: 100dvh;
+  background: var(--ink);
+  color: var(--bone);
+  font-family: var(--font-sans);
+  font-size: var(--fs-13);
+  line-height: 1.35;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow: hidden;
+}
+
+button { font: inherit; color: inherit; background: transparent; border: 0; cursor: pointer; }
+button:focus-visible { outline: 1.5px solid var(--flare); outline-offset: 2px; border-radius: 4px; }
+
+/* =========================================================
+   LAYOUT — three columns
+   ========================================================= */
+
+.app {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) 340px;
+  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "rail stage     panel"
+    "rail transport panel";
+  height: 100dvh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+.rail      { grid-area: rail; }
+.stage     { grid-area: stage; }
+.transport { grid-area: transport; }
+.panel     { grid-area: panel; }
+
+.rail, .panel, .stage { min-width: 0; }
+
+/* =========================================================
+   LEFT RAIL
+   ========================================================= */
+
+.rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--s-16) 0;
+  border-right: 1px solid var(--hull);
+  background: var(--ink);
+}
+
+.rail__logo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 4px;
+  filter: invert(1) brightness(1.1);
+}
+.rail__logo img { width: 26px; height: auto; display: block; }
+.rail__logo img:last-child { width: 36px; }
+
+.rail__spacer { flex: 1; }
+.rail__btn {
+  width: 40px;
+  height: 40px;
+  color: var(--fog);
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
+}
+.rail__btn:hover { color: var(--flare); background: rgba(255,107,44,0.06); }
+.rail__btn svg { width: 18px; height: 18px; }
+
+/* =========================================================
+   STAGE — radar + chrome
+   ========================================================= */
+
+.stage {
+  display: flex;
+  flex-direction: column;
+  padding: var(--s-12) var(--s-16);
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse at center, rgba(117,251,76,0.02) 0%, transparent 60%),
+    var(--ink);
+}
+/* stage head removed; radar is hero directly */
+
+/* Radar holder */
+.radar {
+  flex: 1 1 0;
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: var(--s-4);
+  contain: size layout;
+}
+#radar-canvas {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: block;
+  touch-action: none;
+  user-select: none;
+}
+
+.radar__range {
+  position: absolute;
+  top: var(--s-16);
+  right: var(--s-16);
+  background: rgba(21, 24, 33, 0.86);
+  border: 1px solid var(--hull);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: var(--bone);
+  border-radius: 6px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  transition: border-color var(--dur) var(--ease);
+  z-index: 2;
+}
+.radar__range:hover { border-color: var(--fog); }
+.range__val { font-family: var(--font-mono); font-size: var(--fs-16); font-weight: 500; }
+.range__unit { font-family: var(--font-mono); font-size: 10px; color: var(--fog); }
+
+/* Transport */
+.transport {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  align-items: center;
+  gap: var(--s-12);
+  padding: var(--s-8) var(--s-16) var(--s-12);
+  border-top: 1px solid var(--hull);
+  background: var(--ink);
+}
+.transport__play {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: var(--bone);
+  color: var(--ink);
+  display: grid;
+  place-items: center;
+  transition: transform var(--dur) var(--ease), background var(--dur) var(--ease);
+}
+.transport__play:hover { transform: scale(1.04); }
+.transport__play svg { width: 12px; height: 12px; }
+.transport__play .icon-pause { display: none; }
+.transport__play.is-playing .icon-play { display: none; }
+.transport__play.is-playing .icon-pause { display: block; }
+
+.transport__clock {
+  font-family: var(--font-mono);
+  font-size: var(--fs-20);
+  font-weight: 500;
+  color: var(--bone);
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  min-width: 110px;
+}
+
+.transport__scrub {
+  position: relative;
+  height: 24px;
+  display: flex;
+  align-items: center;
+}
+.scrub__track {
+  position: absolute; inset: 11px 0 11px 0;
+  background: var(--hull);
+  border-radius: 1px;
+}
+.scrub__fill {
+  position: absolute; left: 0; top: 11px; bottom: 11px;
+  width: var(--pct, 0%);
+  background: var(--bone);
+  border-radius: 1px;
+}
+.scrub__head {
+  position: absolute;
+  left: var(--pct, 0%);
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 10px; height: 10px;
+  background: var(--bone);
+  border-radius: 50%;
+}
+
+.transport__speeds { display: flex; gap: 2px; padding: 3px; background: var(--steel); border-radius: 6px; }
+.speed {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  padding: 6px 10px;
+  border-radius: 4px;
+  color: var(--fog);
+  transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
+}
+.speed:hover { color: var(--bone-dim); }
+.speed.is-active { background: var(--ink); color: var(--bone); }
+
+/* =========================================================
+   RIGHT PANEL — telemetry
+   ========================================================= */
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  padding: var(--s-16) var(--s-16) var(--s-8);
+  border-left: 1px solid var(--hull);
+  background: var(--ink-2);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+/* Section dividers — horizontal rules, not cards */
+.panel > section + section {
+  margin-top: var(--s-16);
+  padding-top: var(--s-16);
+  border-top: 1px solid var(--hull);
+}
+
+/* TRACK SECTION */
+.track { display: flex; flex-direction: column; gap: var(--s-12); }
+.track__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--s-12);
+}
+.track__tag {
+  font-family: var(--font-display);
+  font-size: var(--fs-20);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--bone);
+}
+.track.is-risk .track__tag { color: var(--flare); }
+.track__state {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fog);
+}
+.track.is-risk .track__state { color: var(--flare); }
+
+/* CBDR strip */
+.cbdr {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  column-gap: var(--s-12);
+  padding: var(--s-8) var(--s-4);
+  color: var(--fog);
+}
+.cbdr[data-state="risk"] { color: var(--flare); }
+.cbdr[data-state="steady"] { color: var(--bone-dim); }
+.cbdr__state {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: inherit;
+}
+.cbdr__spark { width: 100%; height: 18px; color: inherit; }
+.cbdr__delta {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--bone);
+  font-variant-numeric: tabular-nums;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+.cbdr__delta .u {
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fog);
+}
+
+/* Hero numbers — raw typography, no containers */
+.hero {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: var(--s-16);
+  align-items: end;
+  padding: var(--s-4) var(--s-4) var(--s-12);
+  border-bottom: 1px solid var(--hull);
+}
+.hero__cell { display: flex; flex-direction: column; gap: 2px; }
+.hero__lbl {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fog);
+}
+.hero__val {
+  font-family: var(--font-mono);
+  font-size: 32px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--bone);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.hero__cell--primary .hero__val { color: var(--flare); }
+.hero__unit {
+  font-size: 12px;
+  color: var(--fog);
+  letter-spacing: 0.08em;
+  font-weight: 400;
+}
+.hero__val-sm {
+  font-family: var(--font-display);
+  font-size: var(--fs-16);
+  font-weight: 600;
+  color: var(--bone);
+}
+.hero__aspect {
+  display: flex;
+  align-items: center;
+  gap: var(--s-8);
+}
+.aspect { width: 56px; height: 56px; flex-shrink: 0; }
+.hero__aspect-txt { display: flex; flex-direction: column; gap: 2px; }
+
+/* Data grid — 4 columns, two rows, dense */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  column-gap: var(--s-4);
+  row-gap: var(--s-8);
+  padding: var(--s-8) var(--s-4) 0;
+}
+.cell { display: flex; flex-direction: column; gap: 2px; }
+.cell__lbl {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fog);
+}
+.cell__val {
+  font-family: var(--font-mono);
+  font-size: var(--fs-16);
+  font-weight: 500;
+  color: var(--bone);
+  font-variant-numeric: tabular-nums;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+}
+.cell__u {
+  font-size: 10px;
+  color: var(--fog);
+  letter-spacing: 0.06em;
+  font-weight: 400;
+}
+
+/* Contacts — compact list, single row per contact */
+.contacts__head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 0 var(--s-4) var(--s-4);
+}
+.contacts__title {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--bone);
+  margin: 0;
+}
+.contacts__count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fog);
+  margin-left: 6px;
+  letter-spacing: 0.04em;
+}
+.contacts__add {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fog);
+  letter-spacing: 0.06em;
+  padding: 4px 6px;
+  border-radius: 3px;
+  transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
+}
+.contacts__add:hover { color: var(--bone); background: rgba(255,255,255,0.04); }
+
+.contacts__list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; }
+.contact {
+  display: grid;
+  grid-template-columns: 10px 40px 1fr 1fr 1fr;
+  align-items: baseline;
+  gap: var(--s-8);
+  padding: 6px var(--s-4);
+  color: var(--bone-dim);
+  cursor: pointer;
+  transition: background var(--dur) var(--ease), color var(--dur) var(--ease);
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.contact:hover { background: rgba(255,255,255,0.03); color: var(--bone); }
+.contact.is-active { color: var(--bone); background: rgba(255,255,255,0.04); }
+.contact__dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--fog);
+  justify-self: center;
+  align-self: center;
+}
+.contact__dot--risk { background: var(--flare); box-shadow: 0 0 0 3px var(--flare-soft); }
+.contact__tag { font-weight: 500; color: var(--bone); letter-spacing: 0.02em; }
+.contact__brg { color: var(--bone-dim); }
+.contact__rng { color: var(--bone-dim); }
+.contact__cpa {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  justify-self: end;
+}
+.cpa-val { color: var(--bone); }
+.cpa-t { font-size: 10px; color: var(--fog); letter-spacing: 0.04em; }
+
+/* Ownship footer */
+.own__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0 var(--s-4);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+.own__lbl {
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fog);
+}
+.own__val {
+  font-size: 13px;
+  color: var(--bone);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.own__val .sep { color: var(--hull); }
+.own__u { font-size: 10px; color: var(--fog); margin-left: 2px; }
+
+/* Editable hot targets */
+.editable {
+  cursor: pointer;
+  border-bottom: 1px dashed transparent;
+  transition: border-color var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+.editable:hover { border-bottom-color: var(--fog); color: var(--bone); }
+.editable.is-editing { border-bottom-color: var(--flare); color: var(--flare); }
+
+/* Contacts empty state */
+.contacts__hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--fog);
+}
+.contacts__empty {
+  padding: var(--s-12) var(--s-4);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--bone-dim);
+  text-align: left;
+  border: 1px dashed var(--hull);
+  border-radius: 4px;
+  margin-top: var(--s-4);
+}
+.contacts__empty-hint { color: var(--fog); }
+.has-contacts .contacts__empty { display: none; }
+
+/* Inline edit popover */
+.edit-pop {
+  position: fixed;
+  z-index: 50;
+  background: var(--steel);
+  border: 1px solid var(--flare-edge);
+  border-radius: 6px;
+  padding: var(--s-8);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  min-width: 140px;
+}
+.edit-pop[hidden] { display: none; }
+.edit-pop__lbl {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fog);
+}
+.edit-pop__input {
+  font-family: var(--font-mono);
+  font-size: var(--fs-16);
+  background: var(--ink);
+  border: 1px solid var(--hull);
+  color: var(--bone);
+  padding: 6px 8px;
+  border-radius: 3px;
+  outline: none;
+  font-variant-numeric: tabular-nums;
+}
+.edit-pop__input:focus { border-color: var(--flare); }
+.edit-pop__hint {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: var(--fog);
+}
+
+/* Topbar mobile button */
+.topbar__btn {
+  width: 40px;
+  height: 40px;
+  color: var(--fog);
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+}
+.topbar__btn svg { width: 18px; height: 18px; }
+
+/* =========================================================
+   MOBILE TOPBAR (hidden on desktop)
+   ========================================================= */
+
+.topbar {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--s-12) var(--s-16);
+  border-bottom: 1px solid var(--hull);
+  background: var(--ink);
+  grid-area: topbar;
+}
+.topbar__logo {
+  display: flex; flex-direction: column; align-items: center; gap: 2px;
+  filter: invert(1) brightness(1.1);
+}
+.topbar__logo img { width: 28px; height: auto; display: block; }
+.topbar__logo img:last-child { width: 40px; }
+
+/* =========================================================
+   TABLET — 1024–1279
+   ========================================================= */
+
+@media (max-width: 1279px) {
+  .app { grid-template-columns: 56px minmax(0, 1fr) 320px; }
+  .stage { padding: var(--s-8) var(--s-12) var(--s-8); }
+  .panel { padding: var(--s-12); }
+  .rail__logo img { width: 22px; }
+  .rail__logo img:last-child { width: 30px; }
+  .contact { grid-template-columns: 10px 40px 1fr 1fr 1fr; }
+  .hero__val { font-size: 28px; }
+}
+
+/* =========================================================
+   MOBILE — below 900px
+   ========================================================= */
+
+@media (max-width: 900px) {
+  .app {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr) auto auto;
+    grid-template-areas:
+      "topbar"
+      "stage"
+      "panel"
+      "transport";
+    height: 100dvh;
+  }
+  .rail { display: none; }
+  .topbar { display: flex; grid-area: topbar; }
+  .stage { padding: var(--s-12) var(--s-16) 0; overflow: hidden; }
+  .radar__range { top: var(--s-8); right: var(--s-8); padding: 6px 10px; }
+  .transport {
+    grid-template-columns: 44px 1fr auto;
+    grid-template-rows: auto auto;
+    gap: var(--s-8) var(--s-12);
+    padding: var(--s-8) var(--s-12) calc(var(--s-12) + env(safe-area-inset-bottom, 0px));
+  }
+  .transport__play { grid-row: 1 / 3; }
+  .transport__clock { grid-column: 2; font-size: var(--fs-20); min-width: 0; }
+  .transport__speeds { grid-column: 3; grid-row: 1; }
+  .transport__scrub { grid-column: 2 / 4; grid-row: 2; }
+
+  /* Panel becomes a swipeable deck */
+  .panel {
+    border-left: none;
+    border-top: 1px solid var(--hull);
+    padding: var(--s-12);
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    flex-direction: row;
+    gap: var(--s-12);
+    max-height: 38dvh;
+  }
+  .panel > section {
+    scroll-snap-align: start;
+    flex: 0 0 86%;
+    max-width: 86%;
+    min-height: auto;
+    overflow-y: auto;
+  }
+  /* reset desktop section dividers on mobile */
+  .panel > section + section {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
+    border-left: 1px solid var(--hull);
+    padding-left: var(--s-12);
+  }
+  .grid { grid-template-columns: repeat(4, 1fr); }
+  .hero { grid-template-columns: 1fr 1fr auto; }
+  .aspect { width: 56px; height: 56px; }
+  .contact { grid-template-columns: 10px 40px 1fr 1fr 1fr; }
+}
+
+/* =========================================================
+   SMALL MOBILE — below 420px
+   ========================================================= */
+
+@media (max-width: 420px) {
+  .transport__speeds { display: none; }
+  .transport { grid-template-columns: 44px 1fr; grid-template-rows: auto auto; }
+  .transport__scrub { grid-column: 1 / 3; grid-row: 2; }
+}


### PR DESCRIPTION
## Summary
- Working sandbox prototype at `prototypes/redesign/` (HTML + CSS + three JS files: `sim.js` physics engine, `radar.js` canvas renderer, `app.js` driver and interactions)
- Physics ported from `js/arena.js`: CPA, bearing/range, relative motion, target angle, bearing rate
- Real interactions: long-press-to-drop + drag-for-course, tap-to-select, inline editors for ownship and active-track course/speed, play/pause, speed chips, range cycle, clear
- 60s bearing sparkline with live drift data, rotating aspect dial, CBDR state classification
- Three responsive breakpoints; on mobile the transport bar is pinned below the telemetry deck for thumb reach, with safe-area-inset padding
- Design spec at `docs/superpowers/specs/2026-04-17-maneuver-ui-redesign-design.md`

Runs via `python3 -m http.server 8765` at `/prototypes/redesign/` — `file://` does not work due to browser origin restrictions.

## Test plan
- [ ] Open http://localhost:8765/prototypes/redesign/ and verify radar renders at 12 NM scale with three seed contacts
- [ ] Long-press radar → ghost appears → drag → release commits a contact on the intended course
- [ ] Click Ownship course/speed and track Crs/Spd values to edit; Enter applies, Esc cancels
- [ ] Play → CBDR strip lights orange on T-01 within the first minute; TCPA counts down
- [ ] Resize to tablet and mobile widths; verify transport stays visible and panel deck swipes horizontally